### PR TITLE
Add the ability to specify custom role config groups for sets of hosts

### DIFF
--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -214,5 +214,5 @@ class FilterModule(object):
         for role_mapping in host_templates.values():
             for (service, roles) in role_mapping.items():
                 for custom_role in filter(lambda x: '/' in x, roles):
-                    custom_role_groups.append("-".join([service, "1"] + custom_role.split("/")))
+                    custom_role_groups.append("-".join([service.lower()] + custom_role.split("/")))
         return custom_role_groups

--- a/roles/cloudera_manager/config/templates/cm_api.j2
+++ b/roles/cloudera_manager/config/templates/cm_api.j2
@@ -31,7 +31,7 @@
   {%- if value_type == "ref" or value_type == "value" -%}
     {{ config.update({ value_type: value }) }}
   {%- else -%}
-    {%- set var_name = [service_type, role_type, key] | join("_") | replace('.','_') -%}
+    {%- set var_name = [service_type, role_type, key] | join("_") | replace('.','_') | replace('/','_') -%}
     {{ config.update({ "variable": var_name | upper }) }}
   {%- endif -%}
   {{ config | to_json }}

--- a/roles/deployment/cluster/templates/cluster_template/base/hostTemplates.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/hostTemplates.j2
@@ -15,7 +15,7 @@
         {{ roles.append("KT_RENEWER") }}
       {%- endif -%}
       {%- for role in roles -%}
-        {%- set (role_type, config_group) = role | extract_role_and_group -%}
+        {%- set (role_type, config_group) = role | cloudera.cluster.extract_role_and_group -%}
         {{ role_config_group_refs.append("{}-{}-{}".format(service_ref, role_type, config_group)) }}
       {%- endfor -%}
     {%- endif -%}

--- a/roles/deployment/cluster/templates/cluster_template/base/hostTemplates.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/hostTemplates.j2
@@ -15,7 +15,8 @@
         {{ roles.append("KT_RENEWER") }}
       {%- endif -%}
       {%- for role in roles -%}
-        {{ role_config_group_refs.append("{}-{}-BASE".format(service_ref, role)) }}
+        {%- set (role_type, config_group) = role | extract_role_and_group -%}
+        {{ role_config_group_refs.append("{}-{}-{}".format(service_ref, role_type, config_group)) }}
       {%- endfor -%}
     {%- endif -%}
   {%- endfor -%}

--- a/roles/deployment/cluster/templates/cluster_template/base/instantiator.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/instantiator.j2
@@ -32,6 +32,15 @@
     "datanodeTransceiverPort": 1004,
     "datanodeWebPort": 1006
     {%- endif -%}
-  }
+  },
   {%- endif -%}
+  "roleConfigGroups": [
+  {%- set role_group_sep = joiner(",") -%}
+  {%- for custom_rcg in cluster.host_templates | extract_custom_role_groups -%}
+    {{ role_group_sep() }}
+    {
+      "rcgRefName": "{{ custom_rcg }}"
+    }
+  {%- endfor -%}
+  ]
 }

--- a/roles/deployment/cluster/templates/cluster_template/base/instantiator.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/instantiator.j2
@@ -32,9 +32,9 @@
     "datanodeTransceiverPort": 1004,
     "datanodeWebPort": 1006
     {%- endif -%}
-  },
+  }
   {%- endif -%}
-  "roleConfigGroups": [
+  , "roleConfigGroups": [
   {%- set role_group_sep = joiner(",") -%}
   {%- for custom_rcg in cluster.host_templates | cloudera.cluster.extract_custom_role_groups -%}
     {{ role_group_sep() }}

--- a/roles/deployment/cluster/templates/cluster_template/base/instantiator.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/instantiator.j2
@@ -36,7 +36,7 @@
   {%- endif -%}
   "roleConfigGroups": [
   {%- set role_group_sep = joiner(",") -%}
-  {%- for custom_rcg in cluster.host_templates | extract_custom_role_groups -%}
+  {%- for custom_rcg in cluster.host_templates | cloudera.cluster.extract_custom_role_groups -%}
     {{ role_group_sep() }}
     {
       "rcgRefName": "{{ custom_rcg }}"

--- a/roles/deployment/cluster/templates/cluster_template/base/services.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/services.j2
@@ -31,6 +31,18 @@
       }
       {%- endfor -%}
     {%- endif -%}
+    {%- endfor -%}
+    {%- for custom_role in cluster.host_templates | extract_custom_roles(service) -%}
+      {%- set (role_type, config_group) = custom_role | extract_role_and_group -%}
+      {{ role_group_sep() }}
+      {
+        "refName": "{{ service_ref }}-{{ role_type }}-{{ config_group }}",
+        "roleType": "{{ role_type }}",
+        {% set config_sep = joiner(",") -%}
+        "configs": {{ cm_api.ApiClusterTemplateConfigList(merged_configs, service, custom_role) }},
+        "base": false
+      }
+    {%- endfor -%}
     ]
   }
   {%- endfor -%}

--- a/roles/deployment/cluster/templates/cluster_template/base/services.j2
+++ b/roles/deployment/cluster/templates/cluster_template/base/services.j2
@@ -22,27 +22,26 @@
     {%- if service_role_types is iterable -%}
       {%- for role_type in service_role_types -%}
       {{ role_group_sep() }}
-      {
-        "refName": "{{ service_ref }}-{{ role_type }}-BASE",
-        "roleType": "{{ role_type }}",
-        {% set config_sep = joiner(",") -%}
-        "configs": {{ cm_api.ApiClusterTemplateConfigList(merged_configs, service, role_type) }},
-        "base": true
-      }
+        {
+          "refName": "{{ service_ref }}-{{ role_type }}-BASE",
+          "roleType": "{{ role_type }}",
+          {% set config_sep = joiner(",") -%}
+          "configs": {{ cm_api.ApiClusterTemplateConfigList(merged_configs, service, role_type) }},
+          "base": true
+        }
+      {%- endfor -%}
+      {%- for custom_role in cluster.host_templates | cloudera.cluster.extract_custom_roles(service) -%}
+        {%- set (role_type, config_group) = custom_role | cloudera.cluster.extract_role_and_group -%}
+        {{ role_group_sep() }}
+        {
+          "refName": "{{ service_ref }}-{{ role_type }}-{{ config_group }}",
+          "roleType": "{{ role_type }}",
+          {% set config_sep = joiner(",") -%}
+          "configs": {{ cm_api.ApiClusterTemplateCustomConfigList(merged_configs, service, role_type, custom_role) }},
+          "base": false
+        }
       {%- endfor -%}
     {%- endif -%}
-    {%- endfor -%}
-    {%- for custom_role in cluster.host_templates | extract_custom_roles(service) -%}
-      {%- set (role_type, config_group) = custom_role | extract_role_and_group -%}
-      {{ role_group_sep() }}
-      {
-        "refName": "{{ service_ref }}-{{ role_type }}-{{ config_group }}",
-        "roleType": "{{ role_type }}",
-        {% set config_sep = joiner(",") -%}
-        "configs": {{ cm_api.ApiClusterTemplateConfigList(merged_configs, service, custom_role) }},
-        "base": false
-      }
-    {%- endfor -%}
     ]
   }
   {%- endfor -%}

--- a/roles/deployment/cluster/templates/cluster_template/cm_api.j2
+++ b/roles/deployment/cluster/templates/cluster_template/cm_api.j2
@@ -31,7 +31,7 @@
   {%- if value_type == "ref" or value_type == "value" -%}
     {{ config.update({ value_type: value }) }}
   {%- else -%}
-    {%- set var_name = [service_type, role_type, key] | join("_") | replace('.','_') -%}
+    {%- set var_name = [service_type, role_type, key] | join("_") | replace('.','_') | replace('/','_') -%}
     {{ config.update({ "variable": var_name | upper }) }}
   {%- endif -%}
   {{ config | to_json }}
@@ -46,6 +46,28 @@
           {%- set config = ApiClusterTemplateConfig(k, service_type, role_type, v, "ref") -%}
         {%- else -%}
           {%- set config = ApiClusterTemplateConfig(k, service_type, role_type, v, "variable") -%}
+        {%- endif -%}
+        {{ config_list.append(config | from_json) }}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endif -%}
+  {{ config_list | to_json }}
+{%- endmacro %}
+
+{% macro ApiClusterTemplateCustomConfigList(service_merged_configs, service_type, role_type, custom_role_type) -%}
+  {%- set config_list = [] -%}
+  {%- if service_type in service_merged_configs -%}
+    {%- if service_merged_configs[service_type][role_type] is mapping -%}
+      {%- set new_merged_configs = service_merged_configs[service_type][custom_role_type] | combine(service_merged_configs[service_type][role_type]) -%}
+      {%- for (k, v) in new_merged_configs.items() -%}
+        {%- if k.endswith("_service") and not "suppression" in k -%}
+          {%- set config = ApiClusterTemplateConfig(k, service_type, custom_role_type, v, "ref") -%}
+        {%- else -%}
+          {%- if k in service_merged_configs[service_type][custom_role_type] %}
+            {%- set config = ApiClusterTemplateConfig(k, service_type, custom_role_type, v, "variable") -%}
+          {%- else -%}
+            {%- set config = ApiClusterTemplateConfig(k, service_type, role_type, v, "variable") -%}
+          {%- endif -%}
         {%- endif -%}
         {{ config_list.append(config | from_json) }}
       {%- endfor -%}

--- a/roles/deployment/cluster/templates/cluster_template/common/variables.j2
+++ b/roles/deployment/cluster/templates/cluster_template/common/variables.j2
@@ -7,7 +7,7 @@
       {%- if configs is mapping -%}
         {%- for (key, val) in configs.items() -%}
         {{ config_joiner() }}
-        {%- set var_name = [service, role_name, key] | join("_") | replace('.','_') -%}
+        {%- set var_name = [service, role_name, key] | join("_") | replace('.','_') | replace('/','_') -%}
         {{ cm_api.ApiConfig(var_name, val, force_uppercase_keys=True) }}
         {%- endfor -%}
       {%- endif -%}

--- a/roles/verify/parcels_and_roles/tasks/check_cluster_config_roles.yml
+++ b/roles/verify/parcels_and_roles/tasks/check_cluster_config_roles.yml
@@ -19,6 +19,7 @@
         invalid_roles: >-
           {{ config.roles
           | flatten
+          | map('regex_replace','/.+','')
           | difference(['SERVICEWIDE'])
           | difference(role_mappings[config.service] | list)
           }}

--- a/roles/verify/parcels_and_roles/tasks/check_template_roles.yml
+++ b/roles/verify/parcels_and_roles/tasks/check_template_roles.yml
@@ -19,6 +19,7 @@
         invalid_roles: >-
           {{
           template.roles
+          | map('regex_replace','/.+','')
           | difference(role_mappings[template.service] | list)
           }}
     - name: Ensure the host template service roles are valid


### PR DESCRIPTION
Adding the ability to specify custom role config groups by using the syntax ROLETYPE/CUSTOMROLENAME as follows:
```IMPALA:
   IMPALAD:
     scratch_dirs: /tmp/impala
   IMPALAD/COORDINATOR:
     impalad_specialization: COORDINATOR_ONLY
   IMPALAD/EXECUTOR:
     impalad_specialization: EXECUTOR_ONLY
```
Includes logic to fold in any default values from the config overlays (TLS, Kerberos, etc) and to inherit any base configs specified (for example `scratch_dirs` above).

Tested on a cluster with and without custom rcgs.