### PR TITLE
El8 support

### DIFF
--- a/roles/cloudera_manager/repo/defaults/main.yml
+++ b/roles/cloudera_manager/repo/defaults/main.yml
@@ -14,6 +14,6 @@
 
 ---
 cloudera_archive_base_url: https://archive.cloudera.com
-cloudera_manager_version: 7.1.4
+cloudera_manager_version: 7.4.4
 
 install_repo_on_host: yes

--- a/roles/cloudera_manager/repo/vars/RedHat.yml
+++ b/roles/cloudera_manager/repo/vars/RedHat.yml
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 ---
+__cloudera_manager_distro_name: "{{ ansible_os_family | lower }}{{ ansible_distribution_major_version }}"
 __cloudera_manager_major_version: "{{ cloudera_manager_version.split('.')[0] }}"
-__cloudera_manager_repo_url_trial: "{{ cloudera_archive_base_url | regex_replace('/?$','') }}/cm{{ __cloudera_manager_major_version }}/{{ cloudera_manager_version }}/redhat7/yum"
-__cloudera_manager_repo_url_paywall: "{{ cloudera_archive_base_url | regex_replace('/?$','') }}/p/cm{{ __cloudera_manager_major_version }}/{{ cloudera_manager_version }}/redhat7/yum"
+__cloudera_manager_repo_url_trial: "{{ cloudera_archive_base_url | regex_replace('/?$','') }}/cm{{ __cloudera_manager_major_version }}/{{ cloudera_manager_version }}/{{ __cloudera_manager_distro_name }}/yum"
+__cloudera_manager_repo_url_paywall: "{{ cloudera_archive_base_url | regex_replace('/?$','') }}/p/cm{{ __cloudera_manager_major_version }}/{{ cloudera_manager_version }}/{{ __cloudera_manager_distro_name }}/yum"
 __cloudera_manager_repo_key_filename: "RPM-GPG-KEY-cloudera"
 __cloudera_manager_repo_key_trial: "{{ __cloudera_manager_repo_url_trial }}/{{ __cloudera_manager_repo_key_filename }}"
 __cloudera_manager_repo_key_paywall: "{{ __cloudera_manager_repo_url_paywall }}/{{ __cloudera_manager_repo_key_filename }}"

--- a/roles/infrastructure/custom_repo/tasks/main.yml
+++ b/roles/infrastructure/custom_repo/tasks/main.yml
@@ -21,6 +21,7 @@
 - name: Install {{ httpd_package }}
   ansible.builtin.package:
     lock_timeout: 60
+    update_cache: yes
     name: "{{ httpd_package }}"
     state: present
 

--- a/roles/infrastructure/rdbms/tasks/postgresql-RedHat.yml
+++ b/roles/infrastructure/rdbms/tasks/postgresql-RedHat.yml
@@ -30,6 +30,15 @@
     gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
   when: not (skip_rdbms_repo_setup | default(False))
 
+- name: disable default Postgres module in Rhel 8
+  command: dnf module disable -y postgresql
+  register: __postgres_module_result
+  changed_when:
+    - '"Disabling modules" in __postgres_module_result.stdout'
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | int >= 8
+
 - name: Install PostgreSQL
   include_role:
     name: geerlingguy.postgresql

--- a/roles/prereqs/os/tasks/main-RedHat.yml
+++ b/roles/prereqs/os/tasks/main-RedHat.yml
@@ -13,6 +13,23 @@
 # limitations under the License.
 
 ---
+- name: Setup System python on Rhel8
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | int >= 8
+  block:
+    - name: install python 2 for CM7
+      ansible.builtin.package:
+        lock_timeout: 180
+        name: python2
+        update_cache: yes
+        state: present
+
+    - name: Set python2 as default 'python' command
+      debug:
+        msg: "Pick up here"
+    - pause:
+
 
 - name: Disable SELinux
   selinux:

--- a/roles/prereqs/os/tasks/main-RedHat.yml
+++ b/roles/prereqs/os/tasks/main-RedHat.yml
@@ -18,18 +18,17 @@
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version | int >= 8
   block:
-    - name: install python 2 for CM7
+    - name: install python versions
       ansible.builtin.package:
         lock_timeout: 180
-        name: python2
+        name: "{{ __pyver_item }}"
         update_cache: yes
         state: present
-
-    - name: Set python2 as default 'python' command
-      debug:
-        msg: "Pick up here"
-    - pause:
-
+      loop:
+        - python3
+        - python2
+      loop_control:
+        loop_var: __pyver_item
 
 - name: Disable SELinux
   selinux:


### PR DESCRIPTION
Disable dnf AppStream module for Postgresql when centos 8 in use
Set default CM version to 7.4.4 in cloudera.cluster
Derive parcel version of el7 or el8 from inventory target OS family in cloudera.cluster.cloudera_manager.repo
Ensure that Python2/3 are present on nodes when deploying on Rhel8 family OS