### PR TITLE
Fix CM5 deployments on Redhat

### DIFF
--- a/roles/cloudera_manager/repo/tasks/main-RedHat.yml
+++ b/roles/cloudera_manager/repo/tasks/main-RedHat.yml
@@ -20,7 +20,7 @@
     description: Cloudera Manager
     baseurl: "{{ cloudera_manager_repo_url }}"
     gpgkey: "{{ cloudera_manager_repo_key }}"
-    gpgcheck: "{{ cloudera_manager_repo_gpgcheck | default('yes') }}"
+    gpgcheck: "{{ cloudera_manager_repo_gpgcheck | default((cloudera_manager_version.split('.')[0] == '5' ) | ternary('no', 'yes')) }}"
     enabled: yes
     username: "{{ cloudera_manager_repo_username | default('') }}"
     password: "{{ cloudera_manager_repo_password | default('') }}"

--- a/roles/cloudera_manager/repo/tasks/main.yml
+++ b/roles/cloudera_manager/repo/tasks/main.yml
@@ -14,10 +14,17 @@
 
 ---
 
-- name: Include variables
+- name: Include variables for not-Debian in cm6/7
   include_vars:
     file: "{{ ansible_os_family }}.yml"
   when: ansible_os_family != "Debian"
+
+- name: Correct repo URL for Redhat with cm5
+  ansible.builtin.set_fact:
+    __cloudera_manager_repo_url_paywall: "{{ cloudera_archive_base_url | regex_replace('/?$','') }}/p/cm{{ __cloudera_manager_major_version }}/redhat/{{ ansible_distribution_major_version }}/x86_64/cm/{{ cloudera_manager_version }}"
+  when:
+    - ansible_os_family != "Debian"
+    - cloudera_manager_version.split('.')[0] == "5"
 
 - name: Include variables
   include_vars:


### PR DESCRIPTION
Disable cloudera manager repo GPG check by default for cm5 deployments
Add URL correction for deployments of cm5 on Redhat to cloudera repo setup

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>