### PR TITLE
Changes required for Core Settings clusters

### DIFF
--- a/roles/config/cluster/base/templates/configs/kerberos-6.x-7.x.j2
+++ b/roles/config/cluster/base/templates/configs/kerberos-6.x-7.x.j2
@@ -2,8 +2,6 @@
 CORE_SETTINGS:
   SERVICEWIDE:
     hadoop_secure_web_ui: true
-    hadoop_security_authentication: kerberos
-    hadoop_security_authorization: true
 HBASE:
   SERVICEWIDE:
     hbase_restserver_security_authentication: kerberos

--- a/roles/deployment/cluster/tasks/create_data_context.yml
+++ b/roles/deployment/cluster/tasks/create_data_context.yml
@@ -28,3 +28,4 @@
     - "'already exists' not in result.json.message | default('')"
   when:
     - cluster.data_contexts is iterable
+    - "'HDFS' in cluster.services"


### PR DESCRIPTION
Hi all, this PR makes the following changes:
Removes the CORE_SETTINGS configs that are auto-configured (must be unset for the cluster to successfully deploy).
Checks that HDFS is present before attempting to create a data context.