### PR TITLE
Helpful errors

### DIFF
--- a/roles/deployment/groupby/tasks/main.yml
+++ b/roles/deployment/groupby/tasks/main.yml
@@ -19,10 +19,15 @@
     key: "{{ 'host_template_' ~ host_template if host_template is defined else 'no_template' }}"
 
 - name: Find the correct host template
-  set_fact:
-    host_template_content: "{{ _pre_template_cluster | json_query(query) | first }}"
+  block:
+  - fail:
+      msg: "Unable to host template {{ host_template }} in the cluster definition"
+    when: content | length == 0
+  - set_fact:
+      host_template_content: "{{ content | first }}"
   vars:
     query: "clusters[].host_templates[].\"{{ host_template }}\""
+    content: "{{ _pre_template_cluster | json_query(query) }}"
   when: host_template is defined
 
 - name: Group by service

--- a/roles/verify/definition/tasks/main.yml
+++ b/roles/verify/definition/tasks/main.yml
@@ -29,7 +29,9 @@
         success_msg: "TLS is configured on a set of nodes"
         fail_msg: >-
           TLS certificate distribution is not configured in the cluster inventory
-          file (set manual_tls_cert_distribution if this is intentional)
+          file.
+          If this is intential, set manual_tls_cert_distribution=true.
+          Otherwise, set tls=true for each host requiring a certificate.
       when: has_tls and not (manual_tls_cert_distribution | default(false))
     - name: Ensure that TLS distribution is not configured in the inventory
       assert:

--- a/roles/verify/parcels_and_roles/tasks/check_template_roles.yml
+++ b/roles/verify/parcels_and_roles/tasks/check_template_roles.yml
@@ -22,6 +22,7 @@
           | map('regex_replace','/.+','')
           | difference(role_mappings[template.service] | list)
           }}
+
     - name: Ensure the host template service roles are valid
       assert:
         that: "{{ invalid_roles | length == 0 }}"
@@ -31,3 +32,12 @@
         fail_msg: >-
           Unknown role(s) {{ invalid_roles }} for service '{{ template.service }}'
           defined in host template '{{ host_template.name }}'.
+
+    - name: Ensure the Tez gateway has been deployed
+      assert:
+        that: "{{ 'GATEWAY' in (host_template.mappings['TEZ'] | default({})) }}"
+        success_msg: The Tez gateway has been included as required
+        fail_msg: The Tez gateway should be colocated with Hive On Tez roles
+      when:
+        - template.service == 'HIVE_ON_TEZ'
+        - "'HIVESERVER2' in template.roles or 'GATEWAY' in template.roles"


### PR DESCRIPTION
This PR improves a number of error messages:

- Error when a host template does not exist (failed with a lookup failure before)
- Message explaining how to configure tls in the tls verify check
- Verify check to ensure that TEZ is included with each HIVESERVER2 HIVE_ON_TEZ role