### PR TITLE
#65 Fix SPARK3_ON_YARN inter-service dependency

### DIFF
--- a/roles/config/cluster/base/templates/configs/inter-service-dependencies.j2
+++ b/roles/config/cluster/base/templates/configs/inter-service-dependencies.j2
@@ -170,9 +170,6 @@ SPARK3_ON_YARN:
 {% if 'HBASE' in cluster.services %}
     hbase_service: hbase
 {% endif %}
-{% if 'HIVE' in cluster.services %}
-    hive_service: hive
-{% endif %}
 
 TEZ:
   SERVICEWIDE:


### PR DESCRIPTION
Remove hive as a dependency : property hive_service does not exist