### PR TITLE
Expand ldap search filters to allow for any legal expression

### DIFF
--- a/roles/cloudera_manager/external_auth/templates/external_auth_configs.j2
+++ b/roles/cloudera_manager/external_auth/templates/external_auth_configs.j2
@@ -14,11 +14,11 @@ LDAP_BIND_DN: {{ auth_provider.ldap_bind_user_dn | default(None) }}
 LDAP_BIND_PW: {{ auth_provider.ldap_bind_password | default(None) }}
 LDAP_DN_PATTERN: {{ auth_provider.ldap_dn_pattern | default(None) }}
 LDAP_GROUP_SEARCH_BASE: {{ auth_provider.ldap_search_base.group | default(None) }}
-LDAP_GROUP_SEARCH_FILTER: "({{ auth_provider.ldap_attribute.member | default('member') }}={0})"
+LDAP_GROUP_SEARCH_FILTER: "{{ auth_provider.ldap_search_filter.group | default('member={0}') }}"
 LDAP_TYPE: {{ auth_provider.type | cloudera.cluster.to_ldap_type_enum | default(None) }}
 LDAP_URL: {{ auth_provider.ldap_url | default(None) }}
 LDAP_USER_SEARCH_BASE: {{ auth_provider.ldap_search_base.user | default(None) }}
-LDAP_USER_SEARCH_FILTER: "({{ auth_provider.ldap_attribute.user | default('sAMAccountName') }}={0})"
+LDAP_USER_SEARCH_FILTER: "{{ auth_provider.ldap_search_filter.user | default('sAMAccountName={0}') }}"
 NT_DOMAIN: {{ auth_provider.domain | default(None) }}
 {% if cloudera_manager_version is version('7.1.0','>=') %}
 FRONTEND_URL: {{ frontend_url | default(None) }}


### PR DESCRIPTION
Expand ldap search filters (user & group) to allow for any legal filter expression.

Older implementation assumed all ldap filters end with "={0}"

This newer implementation allows the user to craft any legal filter expression, including complex compound expressions, like
(&(|(member={0})(member={1}))(objectClass=group))
Introduces attribute: auth_provider.ldap_search_filter.group
obsoletes attribute: auth_provider.ldap_search_filter.member
Signed-off-by: Chuck Levesque <clevesque@cloudera.com>
