### PR TITLE
Updates for private IP installations

### DIFF
--- a/roles/cloudera_manager/admin_password/check/tasks/main.yml
+++ b/roles/cloudera_manager/admin_password/check/tasks/main.yml
@@ -24,6 +24,7 @@
 
 # https://github.com/ansible/ansible/issues/34989
 - name: Check the default Cloudera Manager admin password
+  delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   uri:
     url: "{{ cloudera_manager_protocol }}://{{ cloudera_manager_host }}:{{ cloudera_manager_port }}/api/v2/tools/echo"
     validate_certs: "{{ cloudera_manager_tls_validate_certs }}"

--- a/roles/cloudera_manager/api_hosts/tasks/main.yml
+++ b/roles/cloudera_manager/api_hosts/tasks/main.yml
@@ -15,6 +15,7 @@
 ---
 
 - name: Get the host identifiers and names from Cloudera Manager
+  delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   cloudera.cluster.cm_api:
     endpoint: /hosts
     method: GET

--- a/roles/cloudera_manager/config/tasks/main.yml
+++ b/roles/cloudera_manager/config/tasks/main.yml
@@ -15,6 +15,7 @@
 ---
 
 - name: Get existing configs
+  delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   cloudera.cluster.cm_api:
     endpoint: "{{ api_config_endpoint }}"
   register: response
@@ -31,6 +32,7 @@
   when: message is defined and "message" not in api_config_endpoint
 
 - name: Update configuration (via Cloudera Manager API)
+  delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   cloudera.cluster.cm_api:
     endpoint: "{{ api_config_endpoint }}"
     body: "{{ lookup('template', 'config.j2', convert_data=False) }}"

--- a/roles/security/tls_install_certs/tasks/main.yml
+++ b/roles/security/tls_install_certs/tasks/main.yml
@@ -14,12 +14,14 @@
 
 ---
 
-- set_fact:
+- name: Set fact for signed TLS certificates directory
+  ansible.builtin.set_fact:
     tls_signed_certs_dir: "{{ local_certs_dir }}"
   when: tls_signed_certs_dir is not defined
 
 # remote certificates for ca_server ca
-- set_fact:
+- name: Define remote certificates for embedded CA server
+  ansible.builtin.set_fact:
     tls_ca_certs:
       - alias: cluster_rootca
         path: "{{ ca_server_root_cert_path }}"
@@ -30,12 +32,22 @@
   when: tls_ca_certs is not defined and 'ca_server' in groups
 
 # remote certificates for freeipa ca
-- set_fact:
+- name: Define remote certificates for embedded FreeIPA server
+  ansible.builtin.set_fact:
     tls_ca_certs:
       - alias: cluster_ca
         path: "/etc/ipa/ca.crt"
-        remote_host: "{{ groups.krb5_server | first | default(omit) }}"
-  when: tls_ca_certs is not defined and krb5_kdc_type | default(None) == 'Red Hat IPA'
+        remote_host: "{{ groups.krb5_server | first }}"
+  when: tls_ca_certs is not defined and 'krb5_server' in groups and krb5_kdc_type | default(None) == 'Red Hat IPA'
+
+# remote certificates for freeipa ca
+- name: Define remote certificates for sidecar FreeIPA server
+  ansible.builtin.set_fact:
+    tls_ca_certs:
+      - alias: cluster_ca
+        path: "/etc/ipa/ca.crt"
+        remote_host: "{{ remote_ipa_server }}"
+  when: tls_ca_certs is not defined and remote_ipa_server is defined and krb5_kdc_type | default(None) == 'Red Hat IPA'
 
 - name: Fetch the remote CA certs
   fetch:


### PR DESCRIPTION
Updates to handle deployments into private, i.e. jump host enabled, installations in cloud providers like AWS EC2