### PR TITLE
removed warn from command args as it is deprecated in 2.14

### DIFF
--- a/roles/cloudera_manager/repo/tasks/main-RedHat.yml
+++ b/roles/cloudera_manager/repo/tasks/main-RedHat.yml
@@ -27,5 +27,3 @@
 
 - name: yum-clean-metadata
   command: yum clean metadata
-  args:
-    warn: no

--- a/roles/infrastructure/rdbms/handlers/main.yml
+++ b/roles/infrastructure/rdbms/handlers/main.yml
@@ -16,5 +16,3 @@
 
 - name: yum clean metadata
   command: yum clean metadata
-  args:
-    warn: no


### PR DESCRIPTION
The warn argument is removed from ansible 2.14 and will cause the playbook to fail.
CC: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_4.html#id72