### PR TITLE
ecs related changes

### DIFF
--- a/roles/cloudera_manager/common/defaults/main.yml
+++ b/roles/cloudera_manager/common/defaults/main.yml
@@ -27,6 +27,6 @@ cloudera_manager_database_type: "{{ database_type }}"
 cloudera_manager_database_name: scm
 cloudera_manager_database_user: scm
 cloudera_manager_database_password: changeme
-cloudera_manager_database_port: "{{ database_port | cloudera.cluster.default_database_port }}"
+cloudera_manager_database_port: "{{ database_type | cloudera.cluster.default_database_port }}"
 cloudera_manager_agent_lib_directory: /var/lib/cloudera-scm-agent
 cloudera_manager_cmf_java_opts_default: "-Xmx4G -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"

--- a/roles/cloudera_manager/services_info/tasks/main.yml
+++ b/roles/cloudera_manager/services_info/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Get All services from CM
   cloudera.cluster.cm_api:
-    endpoint: "/clusters/{{ cluster_name | urlencode() }}/services"
+    endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services"
   register: cloudera_manager_all_services
   no_log: yes  # overly verbose
 
@@ -26,7 +26,7 @@
 
 - name: Get cluster parcel details
   cloudera.cluster.cm_api:
-    endpoint: /clusters/{{ cluster_name | urlencode() }}/parcels
+    endpoint: /clusters/{{ cluster_name_external | urlencode() }}/parcels
   register: parcels_response
 
 - name: Extract active parcels
@@ -111,7 +111,7 @@
   block:
     - name: Get detailed service WXM from CM
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ wxm_service_name | lower }}/roles"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ wxm_service_name | lower }}/roles"
       register: cloudera_manager_wxm_all_roles
       no_log: yes  # overly verbose
 
@@ -122,7 +122,7 @@
 
     - name: Get detailed config WXM from CM
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ wxm_service_name | lower }}/roleConfigGroups/{{ wxm_service_name | lower }}-THUNDERHEAD_SIGMA_CONSOLE-BASE/config?view=full"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ wxm_service_name | lower }}/roleConfigGroups/{{ wxm_service_name | lower }}-THUNDERHEAD_SIGMA_CONSOLE-BASE/config?view=full"
       register: cloudera_manager_wxm_all_rcgs
       no_log: yes  # overly verbose
 
@@ -156,17 +156,17 @@
     - set_fact:
         ranger_server: "{{ cm_deployment_services.json | community.general.json_query(query) }}"
       vars:
-        query: "clusters[?name == '{{ cluster_name | urlencode() }}' ].services[].roles[?type == 'RANGER_ADMIN'][].hostRef.hostname | [0]"
+        query: "clusters[?name == '{{ cluster_name_external | urlencode() }}' ].services[].roles[?type == 'RANGER_ADMIN'][].hostRef.hostname | [0]"
 
     - name: Get Ranger full config
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ ranger_service_name | lower }}/config?view=full"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ ranger_service_name | lower }}/config?view=full"
       register: full_ranger_config
       no_log: yes  # overly verbose
 
     - name: Get Ranger Admin full config
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ ranger_service_name | lower }}/roleConfigGroups/{{ ranger_service_name | lower }}-RANGER_ADMIN-BASE/config?view=full"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ ranger_service_name | lower }}/roleConfigGroups/{{ ranger_service_name | lower }}-RANGER_ADMIN-BASE/config?view=full"
       register: full_ranger_admin_config
       no_log: yes  # overly verbose
 
@@ -217,7 +217,7 @@
   block:
     - name: Get SolR roles
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ solr_service_name | lower }}/roles"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ solr_service_name | lower }}/roles"
       register: solr_roles
       no_log: yes  # overly verbose
 
@@ -228,13 +228,13 @@
 
     - name: Get SolR full config
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ solr_service_name | lower }}/config?view=full"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ solr_service_name | lower }}/config?view=full"
       register: solr_full_config
       no_log: yes  # overly verbose
 
     - name: Get SolR full config for SOLR_SERVER-BASE
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ solr_service_name | lower }}/roleConfigGroups/{{ solr_service_name | lower }}-SOLR_SERVER-BASE/config?view=full"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ solr_service_name | lower }}/roleConfigGroups/{{ solr_service_name | lower }}-SOLR_SERVER-BASE/config?view=full"
       register: solr_full_config_base
       no_log: yes  # overly verbose
 
@@ -296,7 +296,7 @@
   block:
     - name: Get Knox Gateway full config
       cloudera.cluster.cm_api:
-        endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ knox_service_name | lower }}/roleConfigGroups/{{ knox_service_name | lower }}-KNOX_GATEWAY-BASE/config?view=full"
+        endpoint: "/clusters/{{ cluster_name_external | urlencode() }}/services/{{ knox_service_name | lower }}/roleConfigGroups/{{ knox_service_name | lower }}-KNOX_GATEWAY-BASE/config?view=full"
       register: knox_full_config
       no_log: yes  # overly verbose
 

--- a/roles/config/services/mgmt/tasks/main.yml
+++ b/roles/config/services/mgmt/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 # This variable is used by other roles
 # please take care when changing it
 - set_fact:
-    databases: "{{ database_defaults | combine(definition.mgmt.databases | default({}), recursive=True) }}"
+    databases: "{{ databases_cm_svcs | combine(definition.mgmt.databases | default({}), recursive=True) }}"
 
 - name: Reset custom configuration dictionary
   set_fact:

--- a/roles/deployment/databases/tasks/mysql.yml
+++ b/roles/deployment/databases/tasks/mysql.yml
@@ -1,0 +1,44 @@
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Create databases
+  mysql_db:
+    name: "{{ databases[service].name }}"
+    encoding: "{{ service | cloudera.cluster.get_database_encoding_mysql }}"
+    collation: "{{ service | cloudera.cluster.get_database_collation_mysql }}"
+  become: yes
+  loop: "{{ databases }}"
+  loop_control:
+    loop_var: service
+  delegate_to: "{{ databases[service].host }}"
+  connection: ssh
+  when: databases[service].host in groups.db_server
+
+- name: Create database users
+  mysql_user:
+    name: "{{ databases[service].user }}"
+    password: "{{ databases[service].password }}"
+    update_password: always
+    host: '%'
+    priv: "{{ databases[service].name }}.*:ALL"
+  no_log: yes
+  become: yes
+  loop: "{{ databases }}"
+  loop_control:
+    loop_var: service
+  delegate_to: "{{ databases[service].host }}"
+  connection: ssh
+  when: databases[service].host in groups.db_server

--- a/roles/deployment/definition/defaults/main.yml
+++ b/roles/deployment/definition/defaults/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ default_database_versions:
   mariadb:
     '7': 10.2
     '8': 10.2
+  mysql:
+    '8': 8.0  
 
 # Located in cloudera.cluster.infrastructure.krb5_common
 #krb5_realm: CLOUDERA.LOCAL
@@ -39,72 +41,44 @@ manual_tls_cert_distribution: false
 local_temp_dir: '/tmp'
 
 database_defaults:
-  ACTIVITYMONITOR:
-    host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: amon
-    user: amon
-    password: "{{ database_default_password }}"
   DAS:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: das
     user: das
     password: "{{ database_default_password }}"
   HIVE:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: metastore
     user: hive
     password: "{{ database_default_password }}"
   HUE:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: hue
     user: hue
     password: "{{ database_default_password }}"
-  NAVIGATOR:
-    host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: nav
-    user: nav
-    password: "{{ database_default_password }}"
-  NAVIGATORMETASERVER:
-    host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: navms
-    user: navms
-    password: "{{ database_default_password }}"
   OOZIE:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: oozie
     user: oozie
     password: "{{ database_default_password }}"
   RANGER:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: ranger
     user: rangeradmin
     password: "{{ database_default_password }}"
-  REPORTSMANAGER:
-    host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: rman
-    user: rman
-    password: "{{ database_default_password }}"
   SCHEMAREGISTRY:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: schemaregistry
     user: schemaregistry
@@ -125,14 +99,14 @@ database_defaults:
     password: "{{ database_default_password }}"
   STREAMS_MESSAGING_MANAGER:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: streamsmsgmgr
     user: streamsmsgmgr
     password: "{{ database_default_password }}"
   SENTRY:
     host: "{{ database_host }}"
-    port: "{{ database_port | cloudera.cluster.default_database_port }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
     type: "{{ database_type }}"
     name: sentry
     user: sentry
@@ -146,6 +120,37 @@ database_defaults:
     user: queryprocessor
     password: "{{ database_default_password }}"
 
+databases_cm_svcs:
+  ACTIVITYMONITOR:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: amon
+    user: amon
+    password: "{{ database_default_password }}"
+  NAVIGATOR:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: nav
+    user: nav
+    password: "{{ database_default_password }}"
+  NAVIGATORMETASERVER:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: navms
+    user: navms
+    password: "{{ database_default_password }}"
+  REPORTSMANAGER:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: rman
+    user: rman
+    password: "{{ database_default_password }}"
+   
+# Deprecated in ecs 1.5.0 +   
 databases_ecs:
   ALERTS:
     host: "{{ database_host }}"

--- a/roles/deployment/definition/defaults/main.yml
+++ b/roles/deployment/definition/defaults/main.yml
@@ -46,38 +46,6 @@ database_defaults:
     name: amon
     user: amon
     password: "{{ database_default_password }}"
-  ALERTS:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-alerts
-    user: db-alerts
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
-  CLASSIC_CLUSTERS:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: classic-clusters
-    user: classic-clusters
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
-  CLUSTER_ACCESS_MANAGER:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-clusteraccessmanager
-    user: db-clusteraccessmanager
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
-  CLUSTER_PROXY:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: cluster-proxy
-    user: cluster-proxy
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
   DAS:
     host: "{{ database_host }}"
     port: "{{ database_port | cloudera.cluster.default_database_port }}"
@@ -85,30 +53,6 @@ database_defaults:
     name: das
     user: das
     password: "{{ database_default_password }}"
-  DEX:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-dex
-    user: db-dex
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
-  DWX:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-dwx
-    user: db-dwx
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
-  ENV:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-env
-    user: db-env
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
   HIVE:
     host: "{{ database_host }}"
     port: "{{ database_port | cloudera.cluster.default_database_port }}"
@@ -123,14 +67,6 @@ database_defaults:
     name: hue
     user: hue
     password: "{{ database_default_password }}"
-  LIFTIE:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-liftie
-    user: db-liftie
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
   NAVIGATOR:
     host: "{{ database_host }}"
     port: "{{ database_port | cloudera.cluster.default_database_port }}"
@@ -145,14 +81,6 @@ database_defaults:
     name: navms
     user: navms
     password: "{{ database_default_password }}"
-  MLX:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-mlx
-    user: db-mlx
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
   OOZIE:
     host: "{{ database_host }}"
     port: "{{ database_port | cloudera.cluster.default_database_port }}"
@@ -174,14 +102,6 @@ database_defaults:
     name: rman
     user: rman
     password: "{{ database_default_password }}"
-  RESOURCEPOOL_MANAGER:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: db-resourcepoolmanager
-    user: db-resourcepoolmanager
-    password: "{{ database_default_password }}"
-    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
   SCHEMAREGISTRY:
     host: "{{ database_host }}"
     port: "{{ database_port | cloudera.cluster.default_database_port }}"
@@ -217,6 +137,96 @@ database_defaults:
     name: sentry
     user: sentry
     password: "{{ database_default_password }}"
+
+  QUERY_PROCESSOR:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: queryprocessor
+    user: queryprocessor
+    password: "{{ database_default_password }}"
+
+databases_ecs:
+  ALERTS:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-alerts
+    user: db-alerts
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  CLASSIC_CLUSTERS:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: classic-clusters
+    user: classic-clusters
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  CLUSTER_ACCESS_MANAGER:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-clusteraccessmanager
+    user: db-clusteraccessmanager
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  CLUSTER_PROXY:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: cluster-proxy
+    user: cluster-proxy
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  DEX:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-dex
+    user: db-dex
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  DWX:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-dwx
+    user: db-dwx
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  ENV:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-env
+    user: db-env
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  LIFTIE:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-liftie
+    user: db-liftie
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  MLX:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-mlx
+    user: db-mlx
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
+  RESOURCEPOOL_MANAGER:
+    host: "{{ database_host }}"
+    port: "{{ database_type | cloudera.cluster.default_database_port }}"
+    type: "{{ database_type }}"
+    name: db-resourcepoolmanager
+    user: db-resourcepoolmanager
+    password: "{{ database_default_password }}"
+    mode: "{{ cluster.ecs_database_mode | default('existing') }}"
   UMS:
     host: "{{ database_host }}"
     port: "{{ database_type | cloudera.cluster.default_database_port }}"
@@ -225,10 +235,3 @@ database_defaults:
     user: db-ums
     password: "{{ database_default_password }}"
     mode: "{{ cluster.ecs_database_mode | default('existing') }}"
-  QUERY_PROCESSOR:
-    host: "{{ database_host }}"
-    port: "{{ database_type | cloudera.cluster.default_database_port }}"
-    type: "{{ database_type }}"
-    name: queryprocessor
-    user: queryprocessor
-    password: "{{ database_default_password }}"

--- a/roles/deployment/definition/defaults/main.yml
+++ b/roles/deployment/definition/defaults/main.yml
@@ -28,6 +28,7 @@ default_database_versions:
     '7': 10.2
     '8': 10.2
   mysql:
+    '7': 5.7
     '8': 8.0  
 
 # Located in cloudera.cluster.infrastructure.krb5_common

--- a/roles/infrastructure/rdbms/tasks/mysql-RedHat.yml
+++ b/roles/infrastructure/rdbms/tasks/mysql-RedHat.yml
@@ -14,29 +14,31 @@
 
 ---
 
-- name: Install MySQL repository
-  yum_repository:
-    name: MySQL
-    description: MySQL {{ database_version }} repository for RHEL/Centos 7
-    baseurl: https://dev.mysql.com/get/mysql80-community-release-el7-7.noarch.rpm
-    gpgkey: https://dev.mysql.com/RPM-GPG-KEY-MySQLDB
-  when: 
-    - not (skip_rdbms_repo_setup | default(False))
-    - ansible_distribution_major_version | int = 7
+- name: Import GPG Key
+  rpm_key:
+    key: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+    state: present
 
-
-
-- name: Install MySQL repository
-  yum_repository:
-    name: MySQL
-    description: MySQL {{ database_version }} repository for RHEL 8
-    baseurl: https://dev.mysql.com/get/mysql80-community-release-el8-4.noarch.rpm
-    gpgkey: https://dev.mysql.com/RPM-GPG-KEY-MySQLDB
+- name: Install MySQL repository el8
+  yum:
+    name: https://repo.mysql.com/mysql80-community-release-el8.rpm
+    update_cache: true
+    lock_timeout: 180
+    state: present 
   when: 
     - not (skip_rdbms_repo_setup | default(False))
     - ansible_distribution_major_version | int >= 8
-    
 
+- name: Install MySQL repository el7
+  yum:
+    name: https://repo.mysql.com/mysql80-community-release-el7.rpm
+    update_cache: true
+    lock_timeout: 180
+    state: present 
+  when: 
+    - not (skip_rdbms_repo_setup | default(False))
+    - ansible_distribution_major_version | int == 7
+    
 
 - name: Install MySQL
   include_role:

--- a/roles/infrastructure/rdbms/tasks/mysql-RedHat.yml
+++ b/roles/infrastructure/rdbms/tasks/mysql-RedHat.yml
@@ -1,0 +1,43 @@
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install MySQL repository
+  yum_repository:
+    name: MySQL
+    description: MySQL {{ database_version }} repository for RHEL/Centos 7
+    baseurl: https://dev.mysql.com/get/mysql80-community-release-el7-7.noarch.rpm
+    gpgkey: https://dev.mysql.com/RPM-GPG-KEY-MySQLDB
+  when: 
+    - not (skip_rdbms_repo_setup | default(False))
+    - ansible_distribution_major_version | int = 7
+
+
+
+- name: Install MySQL repository
+  yum_repository:
+    name: MySQL
+    description: MySQL {{ database_version }} repository for RHEL 8
+    baseurl: https://dev.mysql.com/get/mysql80-community-release-el8-4.noarch.rpm
+    gpgkey: https://dev.mysql.com/RPM-GPG-KEY-MySQLDB
+  when: 
+    - not (skip_rdbms_repo_setup | default(False))
+    - ansible_distribution_major_version | int >= 8
+    
+
+
+- name: Install MySQL
+  include_role:
+    name: ansible-role-mysql

--- a/roles/infrastructure/rdbms/tasks/mysql-RedHat.yml
+++ b/roles/infrastructure/rdbms/tasks/mysql-RedHat.yml
@@ -18,28 +18,19 @@
   rpm_key:
     key: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
     state: present
+  when: 
+    - not (skip_rdbms_repo_setup | default(False))
 
-- name: Install MySQL repository el8
+- name: Install MySQL Community repository
   yum:
-    name: https://repo.mysql.com/mysql80-community-release-el8.rpm
+    name: https://repo.mysql.com/mysql{{ database_version | replace('.','') }}-community-release-el{{ ansible_distribution_major_version }}.rpm
     update_cache: true
     lock_timeout: 180
     state: present 
   when: 
     - not (skip_rdbms_repo_setup | default(False))
-    - ansible_distribution_major_version | int >= 8
-
-- name: Install MySQL repository el7
-  yum:
-    name: https://repo.mysql.com/mysql80-community-release-el7.rpm
-    update_cache: true
-    lock_timeout: 180
-    state: present 
-  when: 
-    - not (skip_rdbms_repo_setup | default(False))
-    - ansible_distribution_major_version | int == 7
     
-
+    
 - name: Install MySQL
   include_role:
     name: ansible-role-mysql

--- a/roles/infrastructure/rdbms/templates/cloudera.cnf
+++ b/roles/infrastructure/rdbms/templates/cloudera.cnf
@@ -1,10 +1,13 @@
 [mysqld]
 log_bin_trust_function_creators = 1
-{% if database_tls and database_version is version('10.2','>=') %}
+{% if database_tls and database_version is version('8.0','>=') %}
 # SSL configuration
 ssl_ca = {{ tls_chain_path }}
 ssl_cert = {{ tls_cert_path_generic }}
 ssl_key = {{ tls_key_path_plaintext_generic }}
+{% if database_version is version('8.0','>=') %}
+require_secure_transport = {{ mysql_require_secure_transport | default('OFF') }}
+{% endif %}
 {% if database_version is version('10.5.2','>=') %}
 require_secure_transport = {{ mysql_require_secure_transport | default('OFF') }}
 {% endif %}

--- a/roles/infrastructure/rdbms/vars/mysql-RedHat.yml
+++ b/roles/infrastructure/rdbms/vars/mysql-RedHat.yml
@@ -1,0 +1,19 @@
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+mysql_packages:
+  - mysql
+  - mysql-server

--- a/roles/infrastructure/rdbms/vars/mysql.yml
+++ b/roles/infrastructure/rdbms/vars/mysql.yml
@@ -1,0 +1,23 @@
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+mysql_daemon: mysqld
+mysql_log_error: /var/log/mysql.log
+mysql_syslog_tag: mysql
+mysql_pid_file: /var/run/mysql/mysql.pid
+mysql_innodb_large_prefix: 0
+mysql_config_include_files:
+  - src: "cloudera.cnf"
+    force: true

--- a/roles/infrastructure/rdbms/vars/postgresql-RedHat.yml
+++ b/roles/infrastructure/rdbms/vars/postgresql-RedHat.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ postgresql_data_dir: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_bin_path: /usr/pgsql-{{ postgresql_version }}/bin
 postgresql_config_path: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_daemon: postgresql-{{ postgresql_version }}.service
+# Removed devel package as avoids dependency on perl-IPC-run in pg 12+
 postgresql_packages:
   - postgresql{{ postgresql_version | regex_replace('\.','') }}
   - postgresql{{ postgresql_version | regex_replace('\.','') }}-server
   - postgresql{{ postgresql_version | regex_replace('\.','') }}-libs
   - postgresql{{ postgresql_version | regex_replace('\.','') }}-contrib
-  - postgresql{{ postgresql_version | regex_replace('\.','') }}-devel
+#  - postgresql{{ postgresql_version | regex_replace('\.','') }}-devel
 postgresql_python_library: python-psycopg2

--- a/roles/prereqs/local_accounts_common/defaults/main.yml
+++ b/roles/prereqs/local_accounts_common/defaults/main.yml
@@ -253,3 +253,12 @@ mariadb_accounts:
     mode: '770'
     shell: /bin/bash
     unencrypted_key_acl: "{{ database_tls }}"
+
+ecs_accounts:
+  - user: cloudera-scm
+    home: /var/lib/cloudera-scm-server
+    comment: Cloudera Manager
+    mode: '770'
+    keystore_acl: True
+    key_acl: True
+    key_password_acl: True

--- a/roles/prereqs/mysql_connector/defaults/main.yml
+++ b/roles/prereqs/mysql_connector/defaults/main.yml
@@ -14,7 +14,7 @@
 
 ---
 
-mysql_connector_url: https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.49.zip
+mysql_connector_url: https://cdn.mysql.com//Downloads/Connector-J/mysql-connector-java-5.1.49.zip
 mysql_connector_checksum: md5:5ecd588e13f14de07faa5c67f5caf3f1
 mysql_connector_download_dir: "{{ local_temp_dir }}"
 mysql_connector_extract_dir: "{{ local_temp_dir }}"

--- a/roles/prereqs/mysql_connector/defaults/main.yml
+++ b/roles/prereqs/mysql_connector/defaults/main.yml
@@ -15,7 +15,7 @@
 ---
 
 mysql_connector_url: https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.49.zip
-mysql_connector_checksum: md5:5da24facd99964f296ecde32abcd2384
+mysql_connector_checksum: md5:5ecd588e13f14de07faa5c67f5caf3f1
 mysql_connector_download_dir: "{{ local_temp_dir }}"
 mysql_connector_extract_dir: "{{ local_temp_dir }}"
 mysql_connector_local_path: "{{ mysql_connector_extract_dir }}/mysql-connector-java-5.1.49/mysql-connector-java-5.1.49-bin.jar"

--- a/roles/prereqs/mysql_connector/defaults/main.yml
+++ b/roles/prereqs/mysql_connector/defaults/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 ---
 
-mysql_connector_url: https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.48.zip
+mysql_connector_url: https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.49.zip
 mysql_connector_checksum: md5:5da24facd99964f296ecde32abcd2384
 mysql_connector_download_dir: "{{ local_temp_dir }}"
 mysql_connector_extract_dir: "{{ local_temp_dir }}"
-mysql_connector_local_path: "{{ mysql_connector_extract_dir }}/mysql-connector-java-5.1.48/mysql-connector-java-5.1.48-bin.jar"
+mysql_connector_local_path: "{{ mysql_connector_extract_dir }}/mysql-connector-java-5.1.49/mysql-connector-java-5.1.49-bin.jar"

--- a/roles/prereqs/mysql_connector/tasks/main.yml
+++ b/roles/prereqs/mysql_connector/tasks/main.yml
@@ -72,9 +72,7 @@
         dest: /usr/include/mysql/my_config.h
 
     - name: Install Mysql packages for python
-      shell: pip install MySQL-python --force-reinstall --ignore-installed
+      shell: /usr/local/bin/pip install mysql-connector-python --force-reinstall --ignore-installed
       ignore_errors: true
 
-    - name: Chmod on mysql python files
-      shell: chmod -R 755 /usr/lib64/python2.7/site-packages/MySQLdb /usr/lib64/python2.7/site-packages/MySQL_python* /usr/lib64/python2.7/site-packages/_mysql*
-      ignore_errors: true
+  

--- a/roles/prereqs/mysql_connector/tasks/main.yml
+++ b/roles/prereqs/mysql_connector/tasks/main.yml
@@ -71,8 +71,9 @@
         src: my_config.h
         dest: /usr/include/mysql/my_config.h
 
-    - name: Install Mysql packages for python
-      shell: /usr/local/bin/pip install mysql-connector-python --force-reinstall --ignore-installed
+## TODO Fix for RHEL8
+    - name: Install Mysql packages for python - PyMySQL
+      shell: /usr/local/bin/pip install PyMySQL --force-reinstall --ignore-installed
       ignore_errors: true
 
   

--- a/roles/prereqs/pvc_ecs/tasks/main.yml
+++ b/roles/prereqs/pvc_ecs/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Fail Fast if ECS OS is not RH family
+  fail: 
+    msg: ECS is not supported on this OS, should be Centos or RHEL
+  when: ansible_os_family != 'RedHat'
+
 - name: Install necessary additional packages
   ansible.builtin.package:
     name: "{{ __package_item }}"
     state: latest
   loop:
     - nfs-utils
+    - iscsi-initiator-utils
   loop_control:
     loop_var: __package_item
 
@@ -33,38 +40,14 @@
         state: present
       loop:
         - iptables
-        - iptables-services
       loop_control:
         loop_var: __iptables_item
 
-    - name: start iptables on rhel7
-      systemd:
-        name: iptables
-        enabled: yes
-        state: started
-        daemon-reload: yes
-
-- name: Setup nftables on rhel8
+- name: Setup iptables on rhel8, including setopt 
   when: ansible_distribution_major_version | int >= 8
-  block:
-    - name: Install iptables for rhel8
-      ansible.builtin.package:
-        lock_timeout: 180
-        name: "{{ __iptables_install_item }}"
-        update_cache: yes
-        state: present
-      loop:
-        - iptables-services
-      loop_control:
-        loop_var: __iptables_install_item
-
-    - name: start nftables on rhel8
-      systemd:
-        name: iptables
-        enabled: yes
-        state: started
-        daemon-reload: yes
-
+  command: dnf install -y iptables --setopt=tsflags=noscripts
+ 
+ 
 - name: Flush IPTables
   ansible.builtin.iptables:
     flush: yes

--- a/roles/prereqs/pvc_ecs/tasks/main.yml
+++ b/roles/prereqs/pvc_ecs/tasks/main.yml
@@ -43,12 +43,14 @@
       loop_control:
         loop_var: __iptables_item
 
-- name: Setup iptables on rhel8, including setopt 
+- name: Setup iptables on rhel8
   when: ansible_distribution_major_version | int >= 8
-  command: dnf install -y iptables --setopt=tsflags=noscripts
- 
- 
-- name: Flush IPTables
+  block:
+    - name: Install iptables for rhel8, using rpm option tsflags=noscripts
+      command: dnf install -y iptables --setopt=tsflags=noscripts
+
+
+- name: Flush iptables
   ansible.builtin.iptables:
     flush: yes
     table: "{{ __iptables_flush_item }}"
@@ -60,3 +62,25 @@
     - security
   loop_control:
     loop_var: __iptables_flush_item
+    
+  ## see https://docs.rke2.io/known_issues
+- name: Set NetworkManager to ignore any ECS calico & flannel interfaces
+  template:
+    src: networkmanager-conf.j2
+    dest: /etc/NetworkManager/conf.d/rke2-canal.config 
+    owner: root
+    group: root
+    mode: 0644
+  when: 
+    - ansible_distribution_major_version|int >= 7 
+    - ansible_facts.services['NetworkManager.service'] is defined
+  
+- name: Reload NetworkManager daemon
+  systemd:
+    state: restarted
+    daemon_reload: true
+    name: NetworkManager.service  
+  when: 
+    - ansible_distribution_major_version|int >= 7 
+    - ansible_facts.services['NetworkManager.service'] is defined
+

--- a/roles/prereqs/pvc_ecs/templates/networkmanager-conf.j2
+++ b/roles/prereqs/pvc_ecs/templates/networkmanager-conf.j2
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=interface-name:cali*;interface-name:flannel*

--- a/roles/security/tls_generate_csr/tasks/acls-ecs.yml
+++ b/roles/security/tls_generate_csr/tasks/acls-ecs.yml
@@ -1,0 +1,158 @@
+# Copyright 2021 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install acls package
+  ansible.builtin.package:
+    lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(60, omit) }}"
+    name: acl
+    state: present
+
+- name: Change permissions on keystore
+  file:
+    state: file
+    path: "{{ tls_keystore_path }}"
+    mode: 0640
+    owner: root
+    group: hadoop
+
+- name: Add ACLs to keystore
+  acl:
+    path: "{{ tls_keystore_path }}"
+    entity: "{{ account.user }}"
+    etype: group
+    permissions: r
+    state: present
+  loop: "{{ ecs_accounts | json_query('[?@.keystore_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)
+
+- name: Change permissions on keystore hard link
+  file:
+    state: file
+    path: "{{ tls_keystore_path_generic }}"
+    mode: 0640
+    owner: root
+    group: hadoop
+
+- name: Add ACLs to keystore hard link
+  acl:
+    path: "{{ tls_keystore_path_generic }}"
+    entity: "{{ account.user }}"
+    etype: group
+    permissions: r
+    state: present
+  loop: "{{ ecs_accounts | json_query('[?@.keystore_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)
+
+- name: Change permissions on private key
+  file:
+    state: file
+    path: "{{ item }}"
+    mode: 0440
+    owner: root
+    group: root
+  loop:
+    - "{{ tls_key_path }}"
+    - "{{ tls_key_path_generic }}"
+
+- name: Add ACLs to private key
+  acl:
+    path: "{{ tls_key_path }}"
+    entity: "{{ account.user }}"
+    etype: group
+    permissions: r
+    state: present
+  loop: "{{ ecs_accounts | json_query('[?@.key_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)
+
+- name: Add ACLs to private key hard link
+  acl:
+    path: "{{ tls_key_path_generic }}"
+    entity: "{{ account.user }}"
+    etype: group
+    permissions: r
+    state: present
+  loop: "{{ ecs_accounts | json_query('[?@.key_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)
+
+- name: Change permissions on key password file
+  file:
+    state: file
+    path: "{{ tls_key_password_file }}"
+    mode: 0440
+    owner: root
+    group: root
+
+- name: Add ACLs to key password file
+  acl:
+    path: "{{ tls_key_password_file }}"
+    entity: "{{ account.user }}"
+    etype: user
+    permissions: r
+    state: present
+  loop: "{{ ecs_accounts | json_query('[?@.key_password_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)
+
+- name: Change permissions on unencrypted key
+  file:
+    state: file
+    path: "{{ item }}"
+    mode: 0440
+    owner: root
+    group: root
+  loop:
+    - "{{ tls_key_path_plaintext }}"
+    - "{{ tls_key_path_plaintext_generic }}"
+
+- name: Add ACLs to unencrypted key
+  acl:
+    path: "{{ tls_key_path_plaintext }}"
+    entity: "{{ account.user }}"
+    etype: group
+    permissions: r
+    state: present
+  loop: "{{ local_accounts | json_query('[?@.unencrypted_key_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)
+
+- name: Add ACLs to unencrypted key hard link
+  acl:
+    path: "{{ tls_key_path_plaintext_generic }}"
+    entity: "{{ account.user }}"
+    etype: group
+    permissions: r
+    state: present
+  loop: "{{ ecs_accounts | json_query('[?@.unencrypted_key_acl]') }}"
+  loop_control:
+    loop_var: account
+    label: "{{ account.user }}"
+  when: account.when | default(True)

--- a/roles/security/tls_generate_csr/tasks/main.yml
+++ b/roles/security/tls_generate_csr/tasks/main.yml
@@ -117,6 +117,11 @@
 
 - name: Set file permissions
   include_tasks: acls.yml
+  when: inventory_hostname not in groups['ecs_nodes'] 
+  
+- name: Set file permissions for ECS
+  include_tasks: acls-ecs.yml
+  when: inventory_hostname in groups['ecs_nodes'] 
 
 - name: Create openssl.cnf for CSR generation
   template:

--- a/roles/teardown/tasks/teardown_ecs.yml
+++ b/roles/teardown/tasks/teardown_ecs.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,6 +54,10 @@
     - _rke2_killall.failed
     - "'No such file or directory' not in _rke2_killall.stderr"
 
+#TODO emove all remaing kubelet or k3s mounts, address global ro mounts left over from nfs
+- name: Remove all remaing kubelet or k3s mounts
+  shell: mount | awk '/on \/var\/lib\/(kubelet|k3s)/{print \$3}' | xargs -r sudo umount -l"
+
 - name: Run rke2 Uninstall
   register: _rke2_uninstall
   shell: /opt/cloudera/parcels/ECS/bin/rke2-uninstall.sh;
@@ -63,11 +67,12 @@
 
 - name: Delete misc
   shell: |
-    rm -rf /ecs/docker/docker-store/
-    rm -rf /ecs/local/*
-    rm -rf /ecs/longhorn/*
+    rm -rf /mnt/docker/*
+    rm -rf /mnt/ecs/local-storage/*
+    rm -rf /mnt2/ecs/longhorn-storage/*
     rm -rf /var/lib/docker_server
     rm -rf /etc/docker/certs.d
+    rm -rf /var/lib/ecs
     systemctl stop iscsid
     yum -y erase iscsi-initiator-utils
     rm -rf /var/lib/iscsi


### PR DESCRIPTION
add ecs_accounts to be distinct fro default_accounts
no longer import rpm package postgresxx-devel to avoid dependency on epel repo rpm perl-IPC-Run in rhel8
remove ecs db schemas from general list of default db's..as external db is deprecated in ecs
process ecs tls acls separately from base

Signed-off-by: Chuck Levesque [clevesque@users.noreply.github.com]