### PR TITLE
Fix/#111

### DIFF
--- a/roles/deployment/databases/tasks/postgresql.yml
+++ b/roles/deployment/databases/tasks/postgresql.yml
@@ -14,6 +14,13 @@
 
 ---
 
+- name: Ensure psycopg2 is installed
+  package:
+    name: "{{ ((hostvars[databases[item].host]['ansible_os_family'] == 'RedHat') and (hostvars[databases[item].host]['ansible_distribution_major_version'] == '7')) | ternary('python-psycopg2', 'python3-psycopg2') }}"
+  delegate_to: "{{ databases[item].host }}"
+  connection: ssh
+  when: databases[item].host in groups.db_server
+
 - name: Create database roles
   postgresql_user:
     name: "{{ databases[item].user }}"

--- a/roles/deployment/databases/tasks/postgresql.yml
+++ b/roles/deployment/databases/tasks/postgresql.yml
@@ -16,11 +16,11 @@
 
 - name: Ensure psycopg2 is installed
   package:
-    name: "{{ ((hostvars[databases[item].host]['ansible_os_family'] == 'RedHat') and (hostvars[databases[item].host]['ansible_distribution_major_version'] == '7')) | ternary('python-psycopg2', 'python3-psycopg2') }}"
-  with_items: "{{ databases }}"
-  delegate_to: "{{ databases[item].host }}"
+    name: "{{ ((hostvars[item]['ansible_os_family'] == 'RedHat') and (hostvars[item]['ansible_distribution_major_version'] == '7')) | ternary('python-psycopg2', 'python3-psycopg2') }}"
+  with_items: "{{ databases | json_query('*.host') | unique }}"
+  delegate_to: "{{ item }}"
   connection: ssh
-  when: databases[item].host in groups.db_server
+  when: item in groups.db_server
 
 - name: Create database roles
   postgresql_user:

--- a/roles/deployment/databases/tasks/postgresql.yml
+++ b/roles/deployment/databases/tasks/postgresql.yml
@@ -17,6 +17,7 @@
 - name: Ensure psycopg2 is installed
   package:
     name: "{{ ((hostvars[databases[item].host]['ansible_os_family'] == 'RedHat') and (hostvars[databases[item].host]['ansible_distribution_major_version'] == '7')) | ternary('python-psycopg2', 'python3-psycopg2') }}"
+  with_items: "{{ databases }}"
   delegate_to: "{{ databases[item].host }}"
   connection: ssh
   when: databases[item].host in groups.db_server


### PR DESCRIPTION
Ensure psycopg2 is installed before running ansible modules that depends on it

Fixing #111

On RHEL 7, yum package is `python-psycopg2`
On RHEL 8, Ubuntu 18.04 & 20.40, apt package is `python3-psycopg2`

At the moment, these are the only OS supported by `cloudera.cluster`