### PR TITLE
Fixes for PvC running on PvC with sidecar FreeIPA

### DIFF
--- a/roles/deployment/databases/tasks/postgresql.yml
+++ b/roles/deployment/databases/tasks/postgresql.yml
@@ -14,14 +14,6 @@
 
 ---
 
-- name: Ensure psycopg2 is installed
-  package:
-    name: "{{ ((hostvars[item]['ansible_os_family'] == 'RedHat') and (hostvars[item]['ansible_distribution_major_version'] == '7')) | ternary('python-psycopg2', 'python3-psycopg2') }}"
-  with_items: "{{ databases | json_query('*.host') | unique }}"
-  delegate_to: "{{ item }}"
-  connection: ssh
-  when: item in groups.db_server
-
 - name: Create database roles
   postgresql_user:
     name: "{{ databases[item].user }}"

--- a/roles/infrastructure/krb5_client/tasks/freeipa.yml
+++ b/roles/infrastructure/krb5_client/tasks/freeipa.yml
@@ -30,6 +30,7 @@
     ipaserver_realm: "{{ krb5_realm }}"
     ipaserver_domain: "{{ krb5_domain | default(krb5_realm | lower) }}"
     ipaclient_servers: "{{ groups['krb5_server'] }}"
+  when: "krb5_kdc_type == 'Red Hat IPA' and 'krb5_server' in groups"
 
 - name: Include Private Cloud config changes
   ansible.builtin.include_tasks: pvc_configs.yml


### PR DESCRIPTION
This PR has two changes required to deploy PvC on IaaS with sidecar FreeIPA (which is installed as part of the pre_setup).

1. Added a guard condition to prevent the FreeIPA client being installed when the `krb5_server` Ansible host group is not defined.
2. Revert the change in #112 which installs the psycopg2 during the db configuration. This fails when the task file is not executed as root user. Configuring of external dependency packages should be done as part of external dependencies - e.g. `cloudera.cluster.infrastructure.rdbms`