### PR TITLE
use spark_on_yarn_service dependency for hive in CDH only

### DIFF
--- a/roles/config/cluster/base/templates/configs/inter-service-dependencies.j2
+++ b/roles/config/cluster/base/templates/configs/inter-service-dependencies.j2
@@ -28,7 +28,9 @@ HIVE:
 {% if 'ATLAS' in cluster.services and not (cdh_cdp_upgrade|default(false)|bool) %}
     atlas_service: atlas
 {% endif %}
+{% if cloudera_runtime_version is version('7.0.0','<=') %}
     spark_on_yarn_service: spark_on_yarn
+{% endif %}
     zookeeper_service: zookeeper
 
 HIVE_ON_TEZ:


### PR DESCRIPTION
Fixes Issue #122

In CDP using spark_on_yarn is not supported anymore (replaced by hive on tez)