### PR TITLE
Add 'freeipa_enroll' optional parameter 

### DIFF
--- a/docs/freeipa.md
+++ b/docs/freeipa.md
@@ -30,9 +30,9 @@ You must also set `krb5_kdc_type: "Red Hat IPA"`.
 
 ### Existing FreeIPA
 
-This case is simple:
+Set `krb5_kdc_host` to your FreeIPA server hostname. The role `infrastructure/krb5_client` will then install the FreeIPA client and enroll it with the designated server.
 
-Please set `krb5_kdc_host` to you FreeIPA server hostname.
+If you wish to suppress the enrollment, say you have already established enrollment outside of the automation, you can set the `freeipa_enroll` parameter to `false`.
 
 ### Playbook-provisioned
 

--- a/roles/infrastructure/krb5_client/defaults/main.yml
+++ b/roles/infrastructure/krb5_client/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+freeipa_enroll: true

--- a/roles/infrastructure/krb5_client/tasks/freeipa.yml
+++ b/roles/infrastructure/krb5_client/tasks/freeipa.yml
@@ -1,4 +1,6 @@
-# Copyright 2021 Cloudera, Inc.
+---
+
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
 - name: Fix FreeIPA Dbus configuration
   include_tasks: freeipa_dbus_patch.yml
   when:
@@ -30,7 +31,7 @@
     ipaserver_realm: "{{ krb5_realm }}"
     ipaserver_domain: "{{ krb5_domain | default(krb5_realm | lower) }}"
     ipaclient_servers: "{{ groups['krb5_server'] }}"
-  when: "krb5_kdc_type == 'Red Hat IPA' and 'krb5_server' in groups"
+  when: freeipa_enroll or 'krb5_server' in groups
 
 - name: Include Private Cloud config changes
   ansible.builtin.include_tasks: pvc_configs.yml


### PR DESCRIPTION
Allow you to suppress client enrollment with an existing FreeIPA server - current operation assumes either enrollment prior to automation or that you are installing the FreeIPA server alongside the client during the automation.