### PR TITLE
Removes dependency block to Pgsql 12 and higher

### DIFF
--- a/roles/infrastructure/rdbms/vars/postgresql-RedHat.yml
+++ b/roles/infrastructure/rdbms/vars/postgresql-RedHat.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cloudera, Inc.
+# Copyright 2023 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ postgresql_data_dir: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_bin_path: /usr/pgsql-{{ postgresql_version }}/bin
 postgresql_config_path: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_daemon: postgresql-{{ postgresql_version }}.service
+# Removed devel package as avoids dependency on perl-IPC-run in pg 12+
 postgresql_packages:
   - postgresql{{ postgresql_version | regex_replace('\.','') }}
   - postgresql{{ postgresql_version | regex_replace('\.','') }}-server
   - postgresql{{ postgresql_version | regex_replace('\.','') }}-libs
   - postgresql{{ postgresql_version | regex_replace('\.','') }}-contrib
-  - postgresql{{ postgresql_version | regex_replace('\.','') }}-devel
+#  - postgresql{{ postgresql_version | regex_replace('\.','') }}-devel
 postgresql_python_library: python-psycopg2


### PR DESCRIPTION
Removes "pg-devel" dependency that blocks deployment of Postgresql 12 and higher
Signed-off-by: Chuck Levesque <clevesque@cloudera.com>