### PR TITLE
Remove extra quote from databases-7.1.0 config condition

### DIFF
--- a/roles/config/cluster/base/vars/main.yml
+++ b/roles/config/cluster/base/vars/main.yml
@@ -21,7 +21,7 @@ custom_config_templates:
 # Custom configurations for databases
   - template: configs/databases.j2
   - template: configs/databases-7.1.0.j2
-    condition: "{{ cloudera_runtime_version is version('7.1.0','>=') and cloudera_runtime_version is version('7.1.9','<') }}""
+    condition: "{{ cloudera_runtime_version is version('7.1.0','>=') and cloudera_runtime_version is version('7.1.9','<') }}"
   - template: configs/databases-7.1.9.j2
     condition: "{{ cloudera_runtime_version is version('7.1.9','>=') }}"
 # Custom configurations for Infra Solr


### PR DESCRIPTION
There's an extra quotation mark in the condition for the configs/databases-7.1.0.j2 custom configuration template variable. This PR fixes that issue.