### PR TITLE
Create module and action plugins for assemble_cluster_template

### DIFF
--- a/plugins/action/assemble_cluster_template.py
+++ b/plugins/action/assemble_cluster_template.py
@@ -85,7 +85,6 @@ class ActionModule(ActionBase):
                         i for i in base if i[idempotent_id] == item[idempotent_id]
                     ]
                     if namesake:
-                        # LOG.warn("List item being replaced, Old: [%s], New: [%s]", namesake[0], item)
                         self.update_dict(
                             namesake[0],
                             item,
@@ -100,7 +99,7 @@ class ActionModule(ActionBase):
             base.append(item)
         base.sort(key=lambda x: json.dumps(x, sort_keys=True))
 
-    def _assemble_fragments(
+    def assemble_fragments(
         self, assembled_file, src_path, regex=None, ignore_hidden=True, decrypt=True
     ):
         # By file name sort order
@@ -128,14 +127,15 @@ class ActionModule(ActionBase):
                     self.update_object(self.MERGED, json.loads(fragment_file.read()))
                 except json.JSONDecodeError as e:
                     raise AnsibleActionFail(
-                        message=f"{to_text(e.msg)}", obj=to_native(e)
+                        message=f"JSON parsing error: {to_text(e.msg)}",
+                        obj=to_native(e),
                     )
 
         # Write out the final assembly
         json.dump(self.MERGED, assembled_file, indent=2, sort_keys=False)
 
-        # Close the assembled file handle
-        assembled_file.close()
+        # Flush the assembled file handle
+        assembled_file.flush()
 
     def run(self, tmp=None, task_vars=None):
         self._supports_check_mode = False
@@ -146,18 +146,29 @@ class ActionModule(ActionBase):
         if task_vars is None:
             task_vars = dict()
 
+        # Handle aliases
         src = self._task.args.get("src", None)
+        if src is None:
+            src = self._task.args.get("cluster_template_src", None)
+
         dest = self._task.args.get("dest", None)
-        remote_src = self._task.args.get("remote_src", False)
+        if dest is None:
+            dest = self._task.args.get("cluster_template")
+
         regexp = self._task.args.get("regexp", None)
-        follow = self._task.args.get("follow", False)
+        if regexp is None:
+            regexp = self._task.args.get("filter", None)
+
+        remote_src = boolean(self._task.args.get("remote_src", False))
+        follow = boolean(self._task.args.get("follow", False))
         ignore_hidden = boolean(self._task.args.get("ignore_hidden", True))
         decrypt = self._task.args.pop("decrypt", True)
 
         try:
             if src is None or dest is None:
-                raise AnsibleActionFail("src and dest are required")
+                raise AnsibleActionFail("Both 'src' and 'dest' are required")
 
+            # If src files are on the remote host, run the module
             if boolean(remote_src, strict=False):
                 result.update(
                     self._execute_module(
@@ -175,14 +186,16 @@ class ActionModule(ActionBase):
             if not os.path.isdir(src):
                 raise AnsibleActionFail(f"Source, {src}, is not a directory")
 
+            # Compile the regexp
             compiled = None
             if regexp is not None:
                 compiled = re.compile(regexp)
 
+            # Assemble the src files into output file
             with tempfile.NamedTemporaryFile(
-                mode="w", encoding="utf-8", dir=C.DEFAULT_LOCAL_TMP, delete=False
+                mode="w", encoding="utf-8", dir=C.DEFAULT_LOCAL_TMP
             ) as assembled:
-                self._assemble_fragments(
+                self.assemble_fragments(
                     assembled,
                     src,
                     regex=compiled,
@@ -190,54 +203,76 @@ class ActionModule(ActionBase):
                     decrypt=decrypt,
                 )
 
-            assembled_checksum = checksum_s(assembled.name)
-            dest = self._remote_expand_user(dest)
-            dest_stat = self._execute_remote_stat(
-                dest, all_vars=task_vars, follow=follow
-            )
+                # Gather the checksums for assembled file and destination file
+                assembled_checksum = checksum_s(assembled.name)
 
-            new_module_args = self._task.args.copy()
-
-            # Purge cloudera.cluster.assemble_cluster_template-specific options
-            for o in ["remote_src", "regexp", "filter", "ignore_hidden", "decrypt", ]:
-                new_module_args.pop(o, None)
-
-            new_module_args.update(dest=dest)
-
-            diff = {}
-            if assembled_checksum != dest_stat["checksum"]:
-                if self._task.diff:
-                    diff = self._get_diff_data(dest, assembled.name, task_vars)
-
-                remote_path = self._connection._shell.join_path(
-                    self._connection._shell.tmpdir, "assembled_cluster_template"
+                dest = self._remote_expand_user(dest)
+                dest_stat = self._execute_remote_stat(
+                    dest, all_vars=task_vars, follow=follow
                 )
-                transfered = self._transfer_file(assembled.name, remote_path)
 
-                self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
+                # Prepare the task arguments for the called submodules
+                submodule_args = self._task.args.copy()
 
-                new_module_args.update(
-                    dict(
-                        src=transfered,
+                # Purge non-submodule arguments
+                for o in [
+                    "cluster_template_src",
+                    "cluster_template",
+                    "remote_src",
+                    "regexp",
+                    "filter",
+                    "ignore_hidden",
+                    "decrypt",
+                ]:
+                    submodule_args.pop(o, None)
+
+                # Update the 'dest' arg
+                submodule_args.update(dest=dest)
+
+                if assembled_checksum != dest_stat["checksum"]:
+                    diff = {}
+                    
+                    if self._task.diff:
+                        diff = self._get_diff_data(dest, assembled.name, task_vars)
+
+                    # Define a temporary remote path for the remote copy
+                    remote_path = self._connection._shell.join_path(
+                        self._connection._shell.tmpdir, "assembled_cluster_template"
                     )
-                )
+                    
+                    # Transfer the file to the remote path
+                    transfered = self._transfer_file(assembled.name, remote_path)
 
-                copy = self._execute_module(
-                    module_name="ansible.legacy.copy",
-                    module_args=new_module_args,
-                    task_vars=task_vars,
-                )
+                    # Update the file permissions on the remote file
+                    self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
 
-                if diff:
-                    copy.update(diff=diff)
-                result.update(copy)
-            else:
-                file = self._execute_module(
-                    module_name="ansible.legacy.file",
-                    module_args=new_module_args,
-                    task_vars=task_vars,
-                )
-                result.update(file)
+                    # Update the 'src' arg with the temporary remote file
+                    submodule_args.update(
+                        dict(
+                            src=transfered,
+                        )
+                    )
+
+                    # Execute the copy
+                    copy = self._execute_module(
+                        module_name="ansible.legacy.copy",
+                        module_args=submodule_args,
+                        task_vars=task_vars,
+                    )
+
+                    if diff:
+                        copy.update(diff=diff)
+                    
+                    result.update(copy)
+                else:
+                    # Gather details on the existing file
+                    file = self._execute_module(
+                        module_name="ansible.legacy.file",
+                        module_args=submodule_args,
+                        task_vars=task_vars,
+                    )
+                    
+                    result.update(file)
         except AnsibleAction as e:
             result.update(e.result)
         finally:

--- a/plugins/action/assemble_cluster_template.py
+++ b/plugins/action/assemble_cluster_template.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import tempfile
+
+from ansible import constants as C
+from ansible.errors import (
+    AnsibleAction,
+    AnsibleError,
+    _AnsibleActionDone,
+    AnsibleActionFail,
+)
+from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.plugins.action import ActionBase
+from ansible.utils.hashing import checksum_s
+
+
+class ActionModule(ActionBase):
+    TRANSFERS_FILES = True
+
+    def process_fragment(self, fh) -> bytes:
+        updated = bytearray(fh.read())
+        updated.extend("\n-------\n".encode())
+        return updated
+
+    def complete_assembly(self, assembled_file):
+        pass
+
+    def _assemble_fragments(
+        self, assembled_file, src_path, regex=None, ignore_hidden=True
+    ):
+        # By file name sort order
+        for f in (
+            to_text(p, errors="surrogate_or_strict")
+            for p in sorted(os.listdir(src_path))
+        ):
+            # Filter by regexp
+            if regex and not regex.search(f):
+                continue
+
+            # Read and process the fragment
+            fragment = os.path.join(src_path, f)
+            if not os.path.isfile(fragment) or (
+                ignore_hidden and os.path.basename(fragment).startswith(".")
+            ):
+                continue
+
+            with open(self._loader.get_real_file(fragment), "rb") as fragment_file:
+                content = self.process_fragment(fragment_file)
+
+            # Write the resulting bytes
+            if content is not None:
+                assembled_file.write(content)
+
+        # Finalize any remaining assembly
+        self.complete_assembly(assembled_file)
+
+        # Close the assembled file handle
+        assembled_file.close()
+
+    def run(self, tmp=None, task_vars=None):
+        self._supports_check_mode = False
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        del tmp  # legacy
+        if task_vars is None:
+            task_vars = dict()
+
+        src = self._task.args.get("src", None)
+        dest = self._task.args.get("dest", None)
+        remote_src = self._task.args.get("remote_src", False)
+        regexp = self._task.args.get("regexp", None)
+        follow = self._task.args.get("follow", False)
+        ignore_hidden = self._task.args.get("ignore_hidden", True)
+
+        try:
+            if src is None or dest is None:
+                raise AnsibleActionFail("src and dest are required")
+
+            if boolean(remote_src, strict=False):
+                result.update(
+                    self._execute_module(
+                        module_name="cloudera.cluster.assemble_cluster_template",
+                        task_vars=task_vars,
+                    )
+                )
+                raise _AnsibleActionDone()
+            else:
+                try:
+                    src = self._find_needle("files", src)
+                except AnsibleError as e:
+                    raise AnsibleActionFail(to_native(e))
+
+            if not os.path.isdir(src):
+                raise AnsibleActionFail(f"Source, {src}, is not a directory")
+
+            compiled = None
+            if regexp is not None:
+                compiled = re.compile(regexp)
+
+            with tempfile.NamedTemporaryFile(
+                dir=C.DEFAULT_LOCAL_TMP, delete=False
+            ) as assembled:
+                self._assemble_fragments(
+                    assembled, src, regex=compiled, ignore_hidden=ignore_hidden
+                )
+
+            assembled_checksum = checksum_s(assembled.name)
+            dest = self._remote_expand_user(dest)
+            dest_stat = self._execute_remote_stat(
+                dest, all_vars=task_vars, follow=follow
+            )
+
+            new_module_args = self._task.args.copy()
+
+            # Purge cloudera.cluster.assemble_cluster_template-specific options
+            for o in ["remote_src", "regexp", "ignore_hidden"]:
+                new_module_args.pop(o, None)
+
+            new_module_args.update(dest=dest)
+
+            diff = {}
+            if assembled_checksum != dest_stat["checksum"]:
+                if self._task.diff:
+                    diff = self._get_diff_data(dest, assembled.name, task_vars)
+
+                remote_path = self._connection._shell.join_path(
+                    self._connection._shell.tmpdir, "assembled_cluster_template"
+                )
+                transfered = self._transfer_file(assembled.name, remote_path)
+
+                self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
+
+                new_module_args.update(
+                    dict(
+                        src=transfered,
+                    )
+                )
+
+                copy = self._execute_module(
+                    module_name="ansible.legacy.copy",
+                    module_args=new_module_args,
+                    task_vars=task_vars,
+                )
+
+                if diff:
+                    copy.update(diff=diff)
+                result.update(copy)
+            else:
+                file = self._execute_module(
+                    module_name="ansible.legacy.file",
+                    module_args=new_module_args,
+                    task_vars=task_vars,
+                )
+                result.update(file)
+        except AnsibleAction as e:
+            result.update(e.result)
+        finally:
+            self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        return result

--- a/plugins/modules/assemble_cluster_template.py
+++ b/plugins/modules/assemble_cluster_template.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: assemble_cluster_template
+short_description: Merge Cloudera Manager cluster template fragments
+description:
+  - Merge Cloudera Manager cluster template fragment files into a single JSON file.
+  - The module supports C(check_mode).
+author:
+  - "Webster Mudge (@wmudge)"
+  - "Ronald Suplina (@rsuplina)"
+  - "Jim Enright (@jenright)"
+  - "Andre Araujo (@asdaraujo)"
+options:
+  method:
+    description:
+      - HTTP method for the CM API endpoint path.
+    type: str
+    required: True
+    choices:
+        - DELETE
+        - POST
+        - PUT
+  body:
+    description:
+      - HTTP body for the CM API endpoint call.
+    type: dict
+extends_documentation_fragment:
+    - action_common_attributes
+    - action_common_attributes.flow
+    - action_common_attributes.files
+    - decrypt
+    - files
+"""
+
+EXAMPLES = r"""
+---
+"""
+
+RETURN = r"""
+---
+"""
+
+import os
+import re
+import tempfile
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+
+class AssembleClusterTemplate(object):
+    def __init__(self, module):
+        self.module = module 
+        
+        # Set parameters
+        self.src = self.module.params["src"]
+        self.dest = self.module.params["dest"]
+        self.backup = self.module.params["backup"]
+        self.remote_src = self.module.params["remote_src"]
+        self.regexp = self.module.params["regexp"]
+        self.ignore_hidden = self.module.params["ignore_hidden"]
+
+        self.unsafe_writes = self.module.params["unsafe_writes"]
+        self.file_perms = self.module.load_file_common_arguments(self.module.params)
+
+        # Initialize the return values
+        self.output = {}
+        self.changed = False
+
+        # Initialize internal values
+        self.compiled = None
+
+        # Execute the logic
+        self.process()
+
+    def process_fragment(self, fh) -> bytes:
+        updated = bytearray(fh.read())
+        updated.extend("\n-------\n".encode())
+        return updated
+
+    def complete_assembly(self, assembled_file):
+        pass
+
+    def _assemble_fragments(self, assembled_file):
+        # By file name sort order
+        for f in sorted(os.listdir(self.src)):
+            # Filter by regexp
+            if self.compiled and not self.compiled.search(f):
+                continue
+
+            # Read and process the fragment
+            fragment = os.path.join(self.src, f)
+            if not os.path.isfile(fragment) or (
+                self.ignore_hidden and os.path.basename(fragment).startswith(".")
+            ):
+                continue
+
+            with open(fragment, "rb") as fragment_file:
+                content = self.process_fragment(fragment_file)
+
+            # Write the resulting bytes
+            if content is not None:
+                assembled_file.write(content)
+
+        # Finalize any remaining assembly
+        self.complete_assembly(assembled_file)
+
+        # Close the assembled file handle
+        assembled_file.close()
+
+    def process(self):
+        # Check source
+        if not os.path.exists(self.src):
+            self.module.fail_json(msg=f"Source, {self.src}, does not exist")
+        elif not os.path.isdir(self.src):
+            self.module.fail_json(msg=f"Source, {self.src}, is not a directory")
+
+        # Compile filter expression
+        if self.regexp is not None:
+            try:
+                self.compiled = re.compile(self.regexp)
+            except re.error as e:
+                self.module.fail_json(
+                    msg=f"Regular expression, {self.regexp} is invalid: {to_native(e)}"
+                )
+
+        # Assemble fragments
+        with tempfile.NamedTemporaryFile(
+            dir=self.module.tmpdir, delete=False
+        ) as assembled:           
+            # Process fragments into temporary file
+            self._assemble_fragments(assembled)
+
+            # Confirm the assembled file is closed
+            if not assembled.closed:
+                self.module.fail_json(
+                    msg=f"Assembled file, {assembled.name}, not closed after fragment processing"
+                )
+
+            # Generate hashes for assembled file
+            assembled_sha1 = self.module.sha1(assembled.name)
+            self.output.update(checksum=assembled_sha1)
+
+            try:
+                md5 = self.module.md5(assembled.name)
+            except ValueError:
+                md5 = None
+            self.output.update(md5sum=md5)
+
+            # Move to destination
+            dest_sha1 = None
+            if os.path.exists(self.dest):
+                dest_sha1 = self.module.sha1(self.dest)
+
+            if assembled_sha1 != dest_sha1:
+                if self.backup and dest_sha1 is not None:
+                    self.output.update(
+                        backup_file=self.module.backup_local(self.dest)
+                    )
+
+                self.module.atomic_move(
+                    assembled.name, self.dest, unsafe_writes=self.unsafe_writes
+                )
+
+                self.changed = True
+
+        # Notify file permissions
+        self.changed = self.module.set_fs_attributes_if_different(
+            self.file_perms, self.changed
+        )
+
+        # Finalize output
+        self.output.update(msg="OK")
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            src=dict(required=True, type="path"),
+            dest=dict(required=True, type="path"),
+            backup=dict(type="bool", default=False),
+            remote_src=dict(type="bool", default=False),
+            regexp=dict(type="str", aliases=["filter"]),
+            ignore_hidden=dict(type="bool", default=True),
+        ),
+        add_file_common_args=True,
+        supports_check_mode=True,
+    )
+
+    result = AssembleClusterTemplate(module)
+
+    output = dict(
+        changed=result.changed,
+        **result.output,
+    )
+
+    module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/assemble_cluster_template.py
+++ b/plugins/modules/assemble_cluster_template.py
@@ -138,7 +138,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.text.converters import to_native, to_text
 
 
 class AssembleClusterTemplate(object):


### PR DESCRIPTION
A module/action pair for building a single, composite Cloudera Manager cluster template from a set of cluster template "fragments." The plugins handle the merger of the JSON configuration files much like `ansible.builtin.assemble` but honor elements of the cluster template schema.