### PR TITLE
Removes blockers to running check mode & diff mode

### DIFF
--- a/roles/deployment/credential/tasks/main.yml
+++ b/roles/deployment/credential/tasks/main.yml
@@ -32,6 +32,7 @@
       no_log: true
       vars:
         __licname: "{{ cloudera_manager_license | regex_replace('(.|\n)*\"name\"\\s*:\\s*\"([^\"]*)\"(.|\n)*', '\\2') }}"
+      check_mode: false
 
     - name: Set password from processed Cloudera License Content
       no_log: true

--- a/roles/prereqs/jdk/tasks/main.yml
+++ b/roles/prereqs/jdk/tasks/main.yml
@@ -56,10 +56,12 @@
 - name: Capture installed Java provider
   shell: /usr/bin/java -version 2>&1 | egrep -o 'Java\(TM\)|OpenJDK' | sed 's/Java(TM)/Oracle/' | tr '[A-Z]' '[a-z]' | head -1
   register: provider
+  check_mode: false
 
 - name: Capture installed Java version
   shell: /usr/bin/java -version 2>&1 | grep version | tr -d '"' | tr "_" " " | awk '{print $3"\n"$4}'
   register: version
+  check_mode: false
 
 - set_fact:
     installed_jdk_provider: "{{ provider.stdout_lines[0] }}"

--- a/roles/prereqs/license/tasks/main.yml
+++ b/roles/prereqs/license/tasks/main.yml
@@ -22,6 +22,7 @@
     - cloudera_manager_license_file
     - "'cloudera_manager' in groups"
     - inventory_hostname in groups['cloudera_manager']
+  check_mode: false
 
 - name: Set license type to Enterprise if license is presented
   ansible.builtin.set_fact:

--- a/roles/prereqs/mysql_connector/tasks/main.yml
+++ b/roles/prereqs/mysql_connector/tasks/main.yml
@@ -35,6 +35,7 @@
     lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(60, omit) }}"
     name: unzip
     state: present
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Extract MySQL Connector/J zip file
   unarchive:
@@ -42,6 +43,7 @@
     dest: "{{ mysql_connector_extract_dir }}"
     exclude:
       - src
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Copy MySQL Connector/J jar file to correct location
   copy:
@@ -49,6 +51,7 @@
     dest: /usr/share/java/mysql-connector-java.jar
     remote_src: yes
     mode: 0644
+  ignore_errors: "{{ ansible_check_mode }}"
 
 # MySql on rhel8 fix
 - name: Fix MySQL on RHEL8
@@ -70,6 +73,7 @@
       template:
         src: my_config.h
         dest: /usr/include/mysql/my_config.h
+      ignore_errors: "{{ ansible_check_mode }}"
 
 ## TODO Fix for RHEL8
     - name: Install Mysql packages for python - PyMySQL

--- a/roles/prereqs/postgresql_connector/tasks/main.yml
+++ b/roles/prereqs/postgresql_connector/tasks/main.yml
@@ -35,6 +35,7 @@
     src: "{{ local_temp_dir }}/postgresql-connector-java.jar"
     dest: /usr/share/java/postgresql-connector-java.jar
     mode: 0644
+  ignore_errors: "{{ ansible_check_mode }}"
 
 # SSB will need the python3-psycopg2 connector
 


### PR DESCRIPTION
Allows copying license file and extracting user/password to run during check/diff mode.
Allows "Capture installed Java provider" & "Capture installed Java version" tasks to run during check/diff mode, so that facts are populated successfully later
Allows Postgres or MySQL Connectors to run during check/diff mode

Signed-off-by: Chuck Levesque <clevesque@cloudera.com>
