### PR TITLE
Allow complex expressions in external authentication LDAP search filters

### DIFF
--- a/roles/cloudera_manager/external_auth/templates/external_auth_configs.j2
+++ b/roles/cloudera_manager/external_auth/templates/external_auth_configs.j2
@@ -24,7 +24,7 @@ LDAP_URL: {{ auth_provider.ldap_url | default(None) }}
 LDAP_USER_SEARCH_BASE: {{ auth_provider.ldap_search_base.user | default(None) }}
 {% if auth_provider.ldap_search_filter.user is defined %}
 LDAP_USER_SEARCH_FILTER: "{{ auth_provider.ldap_search_filter.user }}"
-{% else % }
+{% else %}
 LDAP_USER_SEARCH_FILTER: "({{ auth_provider.ldap_attribute.user | default('sAMAccountName') }}={0})"
 {% endif %}
 NT_DOMAIN: {{ auth_provider.domain | default(None) }}


### PR DESCRIPTION
Add option for complex LDAP search filters. Older implementation assumed all ldap filters end with "={0}". This newer implementation allows the user to craft any legal filter expression, including complex compound expressions, like ((&(member={0})(objectclass=posixgroup)(!(cn=admin))). This example would handle the IPA group search filter for ECS 1.5.x