### PR TITLE
Hotfix/cluster module

### DIFF
--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -925,7 +925,7 @@ class ClouderaCluster(ClouderaManagerModule):
             warn_fn=self.module.warn, error_fn=self.module.fail_json
         )
         TEMPLATE.merge(template_contents, explicit_params)
-        payload.update(body=ApiClusterTemplate(**template_contents))
+        payload.update(body=template_contents)
 
         # Update to include repositories
         if self.add_repositories:


### PR DESCRIPTION
Fix for Import Cluster method in Cluster module:
Cluster Template arrives in `CamelCase`, Import cluster endpoint also expects `CamelCase`.
ApiClusterTemplate class expects `snake_case` (example `host_templates`, not `hostTemplates`) , which makes ApiClusterTemplate unnecessary here, and module breaks if ApiClusterTemplate is here.