### PR TITLE
Update cm_service_role module and tests

### DIFF
--- a/plugins/module_utils/cm_utils.py
+++ b/plugins/module_utils/cm_utils.py
@@ -35,8 +35,6 @@ from cm_client import (
     ApiClient,
     ApiCommand,
     ApiConfigList,
-    ApiRole,
-    ApiRoleConfigGroup,
     Configuration,
 )
 from cm_client.rest import ApiException, RESTClientObject
@@ -47,34 +45,8 @@ from cm_client.apis.commands_resource_api import CommandsResourceApi
 __credits__ = ["frisch@cloudera.com"]
 __maintainer__ = ["wmudge@cloudera.com"]
 
-ROLE_OUTPUT = [
-    "commission_state",
-    "config_staleness_status",
-    "ha_status",
-    "health_checks",
-    "health_summary",
-    # "host_ref",
-    "maintenance_mode",
-    "maintenance_owners",
-    "name",
-    # "role_config_group_ref",
-    "role_state",
-    # "service_ref",
-    "tags",
-    "type",
-    "zoo_keeper_server_mode",
-]
 
-ROLE_CONFIG_GROUP = [
-    "name",
-    "role_type",
-    "base",
-    "display_name",
-    # "service_ref",
-]
-
-
-def _parse_output(entity: dict, filter: list) -> dict:
+def normalize_output(entity: dict, filter: list) -> dict:
     output = {}
     for k in filter:
         if k == "tags":
@@ -82,24 +54,6 @@ def _parse_output(entity: dict, filter: list) -> dict:
         else:
             output[k] = entity[k]
 
-    return output
-
-
-def parse_role_result(role: ApiRole) -> dict:
-    # Retrieve only the host_id, role_config_group, and service identifiers
-    output = dict(
-        host_id=role.host_ref.host_id,
-        role_config_group_name=role.role_config_group_ref.role_config_group_name,
-        service_name=role.service_ref.service_name,
-    )
-    output.update(_parse_output(role.to_dict(), ROLE_OUTPUT))
-    return output
-
-
-def parse_role_config_group_result(role_config_group: ApiRoleConfigGroup) -> dict:
-    # Retrieve only the service identifier
-    output = dict(service_name=role_config_group.service_ref.service_name)
-    output.update(_parse_output(role_config_group.to_dict(), ROLE_CONFIG_GROUP))
     return output
 
 

--- a/plugins/module_utils/cm_utils.py
+++ b/plugins/module_utils/cm_utils.py
@@ -34,6 +34,7 @@ from time import sleep
 from cm_client import (
     ApiClient,
     ApiCommand,
+    ApiConfig,
     ApiConfigList,
     Configuration,
 )
@@ -143,6 +144,25 @@ def resolve_tag_updates(
             delta_del = {k: v for k, v in diff[1].items() if k in diff[0]}
 
     return (delta_add, delta_del)
+
+
+class ConfigListUpdates(object):
+    def __init__(self, existing: ApiConfigList, updates: dict, purge: bool) -> None:
+        current = {r.name: r.value for r in existing.items}
+        changeset = resolve_parameter_updates(current, updates, purge)
+
+        self.diff = dict(
+            before={k: current[k] if k in current else None for k in changeset.keys()},
+            after=changeset,
+        )
+
+        self.config = ApiConfigList(
+            items=[ApiConfig(name=k, value=v) for k, v in changeset.items()]
+        )
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.config.items)
 
 
 class ClusterTemplate(object):

--- a/plugins/module_utils/data_context_utils.py
+++ b/plugins/module_utils/data_context_utils.py
@@ -17,7 +17,7 @@ A common functions for Cloudera Manager service management
 """
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
-    _parse_output,
+    normalize_output,
 )
 from cm_client import ApiDataContextList
 
@@ -38,9 +38,9 @@ DATA_CONTEXT_OUTPUT = [
 ]
 
 
-def _parse_output(data: dict, keys: list) -> dict:
+def normalize_output(data: dict, keys: list) -> dict:
     return {key: data[key] for key in keys if key in data}
 
 
 def parse_data_context_result(data_contexts: ApiDataContextList) -> list:
-    return [_parse_output(item, DATA_CONTEXT_OUTPUT) for item in data_contexts.items]
+    return [normalize_output(item, DATA_CONTEXT_OUTPUT) for item in data_contexts.items]

--- a/plugins/module_utils/host_utils.py
+++ b/plugins/module_utils/host_utils.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A common functions for Cloudera Manager hosts
+"""
+
+from cm_client import (
+    ApiClient,
+    ApiHost,
+    ApiHostRef,
+    HostsResourceApi,
+)
+from cm_client.rest import ApiException
+
+
+def get_host(
+    api_client: ApiClient, hostname: str = None, host_id: str = None
+) -> ApiHost:
+    if hostname:
+        return next(
+            (
+                h
+                for h in HostsResourceApi(api_client).read_hosts().items
+                if h.hostname == hostname
+            ),
+            None,
+        )
+    else:
+        try:
+            return HostsResourceApi(api_client).read_host(host_id)
+        except ApiException as ex:
+            if ex.status != 404:
+                raise ex
+            else:
+                return None
+
+
+def get_host_ref(
+    api_client: ApiClient, hostname: str = None, host_id: str = None
+) -> ApiHostRef:
+    host = get_host(api_client, hostname, host_id)
+    if host is not None:
+        return ApiHostRef(host.host_id, host.hostname)
+    else:
+        return None

--- a/plugins/module_utils/parcel_utils.py
+++ b/plugins/module_utils/parcel_utils.py
@@ -23,7 +23,7 @@ from enum import IntEnum
 from cm_client import ApiParcel, ParcelResourceApi
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
-    _parse_output,
+    normalize_output,
 )
 
 
@@ -138,5 +138,5 @@ PARCEL = [
 def parse_parcel_result(parcel: ApiParcel) -> dict:
     # Retrieve only the cluster identifier
     output = dict(cluster_name=parcel.cluster_ref.cluster_name)
-    output.update(_parse_output(parcel.to_dict(), PARCEL))
+    output.update(normalize_output(parcel.to_dict(), PARCEL))
     return output

--- a/plugins/module_utils/role_config_group_utils.py
+++ b/plugins/module_utils/role_config_group_utils.py
@@ -19,6 +19,7 @@ from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
 from cm_client import (
     ApiClient,
     ApiRoleConfigGroup,
+    ApiRoleConfigGroupRef,
     RoleConfigGroupsResourceApi,
     MgmtRoleConfigGroupsResourceApi,
 )
@@ -33,6 +34,10 @@ ROLE_CONFIG_GROUP = [
 
 
 class BaseRoleConfigGroupDiscoveryException(Exception):
+    pass
+
+
+class RoleConfigGroupDiscoveryException(Exception):
     pass
 
 
@@ -87,3 +92,16 @@ def get_mgmt_base_role_config_group(
         raise BaseRoleConfigGroupDiscoveryException(role_count=len(rcgs))
     else:
         return rcgs[0]
+
+
+def get_role_config_group(
+    api_client: ApiClient, cluster_name: str, service_name: str, name: str
+) -> ApiRoleConfigGroup:
+    rcg_api = RoleConfigGroupsResourceApi(api_client)
+
+    rcg = rcg_api.read_role_config_group(cluster_name, name, service_name)
+
+    if rcg is None:
+        raise RoleConfigGroupDiscoveryException(name)
+    else:
+        return rcg

--- a/plugins/module_utils/role_config_group_utils.py
+++ b/plugins/module_utils/role_config_group_utils.py
@@ -12,35 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-A common functions for Cloudera Manager cluster management
-"""
-
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     normalize_output,
 )
 
-from cm_client import ApiCluster
+from cm_client import ApiRoleConfigGroup
 
 
-CLUSTER_OUTPUT = [
+ROLE_CONFIG_GROUP = [
     "name",
+    "role_type",
+    "base",
     "display_name",
-    # "full_version",
-    "maintenance_mode",
-    "maintenance_owners",
-    # "services",
-    # "parcels",
-    "entity_status",
-    "uuid",
-    # "data_context_refs",
-    "cluster_type",
-    "tags",
+    # "service_ref",
 ]
 
 
-def parse_cluster_result(cluster: ApiCluster) -> dict:
-    # Retrieve full_version as version
-    output = dict(version=cluster.full_version)
-    output.update(normalize_output(cluster.to_dict(), CLUSTER_OUTPUT))
+def parse_role_config_group_result(role_config_group: ApiRoleConfigGroup) -> dict:
+    # Retrieve only the service identifier
+    output = dict(service_name=role_config_group.service_ref.service_name)
+    output.update(normalize_output(role_config_group.to_dict(), ROLE_CONFIG_GROUP))
     return output

--- a/plugins/module_utils/role_config_group_utils.py
+++ b/plugins/module_utils/role_config_group_utils.py
@@ -37,9 +37,25 @@ class BaseRoleConfigGroupDiscoveryException(Exception):
 
 
 def parse_role_config_group_result(role_config_group: ApiRoleConfigGroup) -> dict:
+    """Parse a Role Config Group into a normalized dictionary.
+
+    Returns the following:
+    - name (str)
+    - role_type (str)
+    - base (bool)
+    - display_name (str)
+    - config (dict)
+
+    Args:
+        role_config_group (ApiRoleConfigGroup): Role Config Group
+
+    Returns:
+        dict: Normalized dictionary of returned values
+    """
     # Retrieve only the service identifier
     output = dict(service_name=role_config_group.service_ref.service_name)
     output.update(normalize_output(role_config_group.to_dict(), ROLE_CONFIG_GROUP))
+    output.update(config={c.name: c.value for c in role_config_group.config.items})
     return output
 
 

--- a/plugins/module_utils/role_utils.py
+++ b/plugins/module_utils/role_utils.py
@@ -16,6 +16,12 @@ from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     normalize_output,
 )
 
+from cm_client import (
+    ApiClient,
+    ApiRoleList,
+    RolesResourceApi,
+    MgmtRolesResourceApi,
+)
 from cm_client import ApiRole
 
 ROLE_OUTPUT = [
@@ -46,3 +52,23 @@ def parse_role_result(role: ApiRole) -> dict:
     )
     output.update(normalize_output(role.to_dict(), ROLE_OUTPUT))
     return output
+
+
+def get_mgmt_roles(api_client: ApiClient, role_type: str) -> ApiRoleList:
+    role_api = MgmtRolesResourceApi(api_client)
+    return ApiRoleList(
+        items=[r for r in role_api.read_roles().items if r.type == role_type]
+    )
+
+
+def get_roles(
+    api_client: ApiClient, cluster_name: str, service_name: str, role_type: str
+) -> ApiRoleList:
+    role_api = RolesResourceApi(api_client)
+    return ApiRoleList(
+        items=[
+            r
+            for r in role_api.read_roles(cluster_name, service_name).items
+            if r.type == role_type
+        ]
+    )

--- a/plugins/module_utils/role_utils.py
+++ b/plugins/module_utils/role_utils.py
@@ -12,35 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-A common functions for Cloudera Manager cluster management
-"""
-
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     normalize_output,
 )
 
-from cm_client import ApiCluster
+from cm_client import ApiRole
 
-
-CLUSTER_OUTPUT = [
-    "name",
-    "display_name",
-    # "full_version",
+ROLE_OUTPUT = [
+    "commission_state",
+    "config_staleness_status",
+    "ha_status",
+    "health_checks",
+    "health_summary",
+    # "host_ref",
     "maintenance_mode",
     "maintenance_owners",
-    # "services",
-    # "parcels",
-    "entity_status",
-    "uuid",
-    # "data_context_refs",
-    "cluster_type",
+    "name",
+    # "role_config_group_ref",
+    "role_state",
+    # "service_ref",
     "tags",
+    "type",
+    "zoo_keeper_server_mode",
 ]
 
 
-def parse_cluster_result(cluster: ApiCluster) -> dict:
-    # Retrieve full_version as version
-    output = dict(version=cluster.full_version)
-    output.update(normalize_output(cluster.to_dict(), CLUSTER_OUTPUT))
+def parse_role_result(role: ApiRole) -> dict:
+    # Retrieve only the host_id, role_config_group, and service identifiers
+    output = dict(
+        host_id=role.host_ref.host_id,
+        role_config_group_name=role.role_config_group_ref.role_config_group_name,
+        service_name=role.service_ref.service_name,
+    )
+    output.update(normalize_output(role.to_dict(), ROLE_OUTPUT))
     return output

--- a/plugins/module_utils/service_utils.py
+++ b/plugins/module_utils/service_utils.py
@@ -17,7 +17,7 @@ A common functions for service management
 """
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
-    _parse_output,
+    normalize_output,
     resolve_parameter_updates,
 )
 
@@ -47,8 +47,13 @@ SERVICE_OUTPUT = [
 def parse_service_result(service: ApiService) -> dict:
     # Retrieve only the cluster_name
     output = dict(cluster_name=service.cluster_ref.cluster_name)
-    output.update(_parse_output(service.to_dict(), SERVICE_OUTPUT))
+    output.update(normalize_output(service.to_dict(), SERVICE_OUTPUT))
     return output
+
+
+def parse_cm_service_result(service: ApiService) -> dict:
+    # Ignore cluster_name
+    return normalize_output(service.to_dict(), SERVICE_OUTPUT)
 
 
 class ServiceConfigUpdates(object):

--- a/plugins/modules/cm_service_role.py
+++ b/plugins/modules/cm_service_role.py
@@ -1,0 +1,740 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = r"""
+module: cm_service_role
+short_description: Manage a Cloudera Manager Service role
+description:
+  - Manage a Cloudera Manager Service role
+author:
+  - "Webster Mudge (@wmudge)"
+requirements:
+  - cm-client
+options:
+  cms_hostname:
+    description:
+      - The hostname of a cluster instance for the role.
+      - Mutually exclusive with I(cluster_host_id).
+    type: str
+    aliases:
+      - cluster_host
+  cms_host_id:
+    description:
+      - The host ID of a cluster instance for the role.
+      - Mutually exclusive with I(cluster_hostname).
+    type: str
+  type:
+    description:
+      - A role type for the role.
+      - Required if the I(state) creates a new role.
+    type: str
+    aliases:
+      - role_type
+  role_config_group:
+    description:
+      - A role type for the role.
+      - Required if the I(state) creates a new role.
+    type: str
+    aliases:
+      - role_type
+  config:
+    description:
+      - The role configuration to set, i.e. overrides.
+      - To unset a parameter, use C(None) as the value.
+    type: dict
+    aliases:
+      - params
+      - parameters
+  maintenance:
+    description:
+      - Flag for whether the role should be in maintenance mode.
+    type: bool
+    aliases:
+      - maintenance_mode
+  tags:
+    description:
+      - A set of tags applied to the role.
+      - To unset a tag, use C(None) as its value.
+    type: dict
+  purge:
+    description:
+      - Flag for whether the declared role tags should append or overwrite any existing tags.
+      - To clear all tags, set I(tags={}), i.e. an empty dictionary, and I(purge=True).
+    type: bool
+    default: False
+  state:
+    description:
+      - The state of the role.
+      - Note, if the declared state is invalid for the role, for example, the role is a C(HDFS GATEWAY), the module will return an error.
+    type: str
+    default: present
+    choices:
+      - present
+      - absent
+      - restarted
+      - started
+      - stopped
+extends_documentation_fragment:
+  - cloudera.cluster.cm_options
+  - cloudera.cluster.cm_endpoint
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms: all
+"""
+
+EXAMPLES = r"""
+- name: Establish a service role (auto-generated name)
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    type: GATEWAY
+    cluster_hostname: worker-01.cloudera.internal
+
+- name: Establish a service role (defined name)
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    type: GATEWAY
+    name: example-gateway
+    cluster_hostname: worker-01.cloudera.internal
+
+- name: Set a service role to maintenance mode
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    maintenance: yes
+
+- name: Update (append) tags to a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    tags:
+      tag_one: value_one
+      tag_two: value_two
+
+- name: Set (purge) tags to a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    tags:
+      tag_three: value_three
+    purge: yes
+
+- name: Remove all tags on a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    tags: {}
+    purge: yes
+
+- name: Start a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    state: started
+
+- name: Force a restart to a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    state: restarted
+
+- name: Start a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    state: started
+
+- name: Remove a service role
+  cloudera.cluster.service_role:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    cluster: example-cluster
+    service: example-hdfs
+    name: example-gateway
+    state: absent
+"""
+
+RETURN = r"""
+role:
+  description: Details about the service role.
+  type: dict
+  contains:
+    name:
+      description: The cluster service role name.
+      type: str
+      returned: always
+    type:
+      description: The cluster service role type.
+      type: str
+      returned: always
+      sample:
+        - NAMENODE
+        - DATANODE
+        - TASKTRACKER
+    host_id:
+      description: The unique ID of the cluster host.
+      type: str
+      returned: always
+    service_name:
+      description: The name of the cluster service, which uniquely identifies it in a cluster.
+      type: str
+      returned: always
+    role_state:
+      description: State of the cluster service role.
+      type: str
+      returned: always
+      sample:
+        - HISTORY_NOT_AVAILABLE
+        - UNKNOWN
+        - STARTING
+        - STARTED
+        - STOPPING
+        - STOPPED
+        - NA
+    commission_state:
+      description: Commission state of the cluster service role.
+      type: str
+      returned: always
+    health_summary:
+      description: The high-level health status of the cluster service role.
+      type: str
+      returned: always
+      sample:
+        - DISABLED
+        - HISTORY_NOT_AVAILABLE
+        - NOT_AVAILABLE
+        - GOOD
+        - CONCERNING
+        - BAD
+    config_staleness_status:
+      description: Status of configuration staleness for the cluster service role.
+      type: str
+      returned: always
+      sample:
+        - FRESH
+        - STALE_REFRESHABLE
+        - STALE
+    health_checks:
+      description: Lists all available health checks for cluster service role.
+      type: list
+      elements: dict
+      returned: when supported
+      contains:
+        name:
+          description: Unique name of this health check.
+          type: str
+          returned: always
+        summary:
+          description: The high-level health status of the health check.
+          type: str
+          returned: always
+          sample:
+            - DISABLED
+            - HISTORY_NOT_AVAILABLE
+            - NOT_AVAILABLE
+            - GOOD
+            - CONCERNING
+            - BAD
+        explanation:
+          description: The explanation of this health check.
+          type: str
+          returned: when supported
+        suppressed:
+          description:
+            - Whether this health check is suppressed.
+            - A suppressed health check is not considered when computing the role's overall health.
+          type: bool
+          returned: when supported
+    maintenance_mode:
+      description: Whether the cluster service role is in maintenance mode.
+      type: bool
+      returned: when supported
+    maintenance_owners:
+      description: The list of objects that trigger this service to be in maintenance mode.
+      type: list
+      elements: str
+      returned: when supported
+      sample:
+        - CLUSTER
+        - SERVICE
+        - ROLE
+        - HOST
+        - CONTROL_PLANE
+    role_config_group_name:
+      description: The name of the cluster service role config group, which uniquely identifies it in a Cloudera Manager installation.
+      type: str
+      returned: when supported
+    tags:
+      description: The dictionary of tags for the cluster service role.
+      type: dict
+      returned: when supported
+    zoo_keeper_server_mode:
+      description:
+        - The Zookeeper server mode for this cluster service role.
+        - Note that for non-Zookeeper Server roles, this will be C(null).
+      type: str
+      returned: when supported
+"""
+
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
+    ClouderaManagerMutableModule,
+    ConfigListUpdates,
+)
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_utils import (
+    create_role,
+    parse_role_result,
+)
+
+from cm_client import (
+    ApiBulkCommandList,
+    ApiRole,
+    ApiRoleList,
+    ApiRoleNameList,
+    ApiRoleState,
+    MgmtRolesResourceApi,
+    MgmtRoleCommandsResourceApi,
+    MgmtServiceResourceApi,
+)
+from cm_client.rest import ApiException
+
+
+class ClouderaManagerServiceRole(ClouderaManagerMutableModule):
+    def __init__(self, module):
+        super(ClouderaManagerServiceRole, self).__init__(module)
+
+        # Set the parameters
+        self.cluster_hostname = self.get_param("cluster_hostname")
+        self.cluster_host_id = self.get_param("cluster_host_id")
+        self.config = self.get_param("config")
+        self.maintenance = self.get_param("maintenance")
+        self.type = self.get_param("type")
+        self.state = self.get_param("state")
+        self.purge = self.get_param("purge")
+
+        # Initialize the return values
+        self.changed = False
+        self.diff = dict(before={}, after={})
+        self.output = {}
+
+        # Execute the logic
+        self.process()
+
+    @ClouderaManagerMutableModule.handle_process
+    def process(self):
+        # Confirm that CMS is present
+        try:
+            MgmtServiceResourceApi(self.api_client).read_service()
+        except ApiException as ex:
+            if ex.status == 404:
+                self.module.fail_json(msg="Cloudera Management Service does not exist")
+            else:
+                raise ex
+
+        self.role_api = MgmtRolesResourceApi(self.api_client)
+
+        current = None
+
+        # Discover the role by its type
+        try:
+            current = next(
+                iter(
+                    [r for r in self.role_api.read_roles().items if r.type == self.type]
+                ),
+                None,
+            )
+            current.config = self.role_api.read_role_config(current.name)
+        except ApiException as ex:
+            if ex.status != 404:
+                raise ex
+
+        # If deleting, do so and exit
+        if self.state == "absent":
+            if current:
+                self.deprovision_role(current)
+
+        # Otherwise, manage the configuration and state
+        elif self.state in ["present", "restarted", "started", "stopped"]:
+            # If it is a new role
+            if not current:
+                new_role = create_role(
+                    api_client=self.api_client,
+                    role_type=self.type,
+                    hostname=self.cluster_hostname,
+                    host_id=self.cluster_host_id,
+                    config=self.config,
+                )
+                current = self.provision_role(new_role)
+            # # If it exists, but the type has changed, destroy and rebuild completely
+            # elif self.type and self.type != current.type:
+            #     new_role = create_role(
+            #         api_client=self.api_client,
+            #         role_type=self.type,
+            #         hostname=current.host_ref.hostname,
+            #         host_id=current.host_ref.host_id,
+            #         config=self.config
+            #     )
+            #     current = self.reprovision_role(current, new_role)
+            # Else it exists, so address any changes
+            else:
+                # Handle role override configurations
+                if self.config or self.purge:
+                    updates = ConfigListUpdates(current.config, self.config, self.purge)
+
+                    if updates.changed:
+                        self.changed = True
+
+                        if self.module._diff:
+                            self.diff["before"].update(config=updates.diff["before"])
+                            self.diff["after"].update(config=updates.diff["after"])
+
+                        if not self.module.check_mode:
+                            self.role_api.update_role_config(
+                                current.name,
+                                message=self.message,
+                                body=updates.config,
+                            )
+
+            # Handle maintenance mode
+            if (
+                self.maintenance is not None
+                and self.maintenance != current.maintenance_mode
+            ):
+                self.changed = True
+
+                if self.module._diff:
+                    self.diff["before"].update(
+                        maintenance_mode=current.maintenance_mode
+                    )
+                    self.diff["after"].update(maintenance_mode=self.maintenance)
+
+                if not self.module.check_mode:
+                    if self.maintenance:
+                        maintenance_cmd = self.role_api.enter_maintenance_mode(
+                            current.name
+                        )
+                    else:
+                        maintenance_cmd = self.role_api.exit_maintenance_mode(
+                            current.name
+                        )
+
+                    if maintenance_cmd.success is False:
+                        self.module.fail_json(
+                            msg=f"Unable to set Maintenance mode to '{self.maintenance}': {maintenance_cmd.result_message}"
+                        )
+
+            # Handle the various states
+            if self.state == "started" and current.role_state not in [
+                ApiRoleState.STARTED
+            ]:
+                self.changed = True
+
+                if self.module._diff:
+                    self.diff["before"].update(role_state=current.role_state)
+                    self.diff["after"].update(role_state="STARTED")
+
+                if not self.module.check_mode:
+                    self.handle_commands(
+                        MgmtRoleCommandsResourceApi(self.api_client).start_command(
+                            body=ApiRoleNameList(items=[current.name]),
+                        )
+                    )
+
+            elif self.state == "stopped" and current.role_state not in [
+                ApiRoleState.STOPPED,
+                ApiRoleState.NA,
+            ]:
+                self.changed = True
+
+                if self.module._diff:
+                    self.diff["before"].update(role_state=current.role_state)
+                    self.diff["after"].update(role_state="STOPPED")
+
+                if not self.module.check_mode:
+                    self.handle_commands(
+                        MgmtRoleCommandsResourceApi(self.api_client).stop_command(
+                            body=ApiRoleNameList(items=[current.name]),
+                        )
+                    )
+
+            elif self.state == "restarted":
+                self.changed = True
+
+                if self.module._diff:
+                    self.diff["before"].update(role_state=current.role_state)
+                    self.diff["after"].update(role_state="STARTED")
+
+                if not self.module.check_mode:
+                    self.handle_commands(
+                        MgmtRoleCommandsResourceApi(self.api_client).restart_command(
+                            body=ApiRoleNameList(items=[current.name]),
+                        )
+                    )
+
+            # If there are changes, get a refresh read
+            if self.changed:
+                refresh = self.role_api.read_role(current.name)
+                refresh.config = self.role_api.read_role_config(current.name)
+                self.output = parse_role_result(refresh)
+            # Otherwise return the existing
+            else:
+                self.output = parse_role_result(current)
+        else:
+            self.module.fail_json(msg=f"Invalid state: {self.state}")
+
+    def provision_role(self, role: ApiRole) -> ApiRole:
+        self.changed = True
+
+        if self.module._diff:
+            self.diff = dict(
+                before={},
+                after=role.to_dict(),
+            )
+
+        if not self.module.check_mode:
+            created_role = next(
+                (
+                    iter(
+                        self.role_api.create_roles(
+                            body=ApiRoleList(items=[role]),
+                        ).items
+                    )
+                ),
+                {},
+            )
+            if not created_role:
+                self.module.fail_json(
+                    msg="Unable to create new role", role=to_native(role.to_dict())
+                )
+
+    def reprovision_role(self, existing_role: ApiRole, new_role: ApiRole) -> ApiRole:
+        self.changed = True
+
+        if self.module._diff:
+            self.diff = dict(
+                before=existing_role.to_dict(),
+                after=new_role.to_dict(),
+            )
+
+        if not self.module.check_mode:
+            self.role_api.delete_role(existing_role.name)
+
+            rebuilt_role = next(
+                (
+                    iter(
+                        self.role_api.create_roles(
+                            body=ApiRoleList(items=[new_role]),
+                        ).items
+                    )
+                ),
+                {},
+            )
+            if not rebuilt_role:
+                self.module.fail_json(
+                    msg="Unable to recreate role, " + existing_role.name,
+                    role=to_native(rebuilt_role.to_dict()),
+                )
+
+    def deprovision_role(self, role: ApiRole):
+        self.changed = True
+
+        if self.module._diff:
+            self.diff = dict(before=role.to_dict(), after=dict())
+
+        if not self.module.check_mode:
+            self.role_api.delete_role(role.name)
+
+    # def xxxcreate_role(self) -> ApiRole:
+    #     # Check for required creation parameters
+    #     missing_params = []
+
+    #     if self.type is None:
+    #         missing_params.append("type")
+
+    #     if self.cluster_hostname is None and self.cluster_host_id is None:
+    #         missing_params += ["cluster_hostname", "cluster_host_id"]
+
+    #     if missing_params:
+    #         self.module.fail_json(
+    #             msg=f"Unable to create new role, missing required arguments: {', '.join(sorted(missing_params)) }"
+    #         )
+
+    #     # Set up the role
+    #     payload = ApiRole(type=str(self.type).upper())
+
+    #     # Name
+    #     if self.name:
+    #         payload.name = self.name # No name allows auto-generation
+
+    #     # Host assignment
+    #     host_ref = get_host_ref(self.api_client, self.cluster_hostname, self.cluster_host_id)
+
+    #     if host_ref is None:
+    #         self.module.fail_json(msg="Invalid host reference")
+    #     else:
+    #         payload.host_ref = host_ref
+
+    #     # Role override configurations
+    #     if self.config:
+    #         payload.config = ApiConfigList(items=[ApiConfig(name=k, value=v) for k, v in self.config.items()])
+
+    #     # Execute the creation
+    #     self.changed = True
+
+    #     if self.module._diff:
+    #         self.diff = dict(
+    #             before={},
+    #             after=payload.to_dict(),
+    #         )
+
+    #     if not self.module.check_mode:
+    #         created_role = next(
+    #             (
+    #                 iter(
+    #                     self.role_api.create_roles(
+    #                         body=ApiRoleList(items=[payload]),
+    #                     ).items
+    #                 )
+    #             ),
+    #             {},
+    #         )
+
+    # # Maintenance
+    # if self.maintenance:
+    #     if self.module._diff:
+    #         self.diff["after"].update(maintenance_mode=True)
+
+    #     maintenance_cmd = self.role_api.enter_maintenance_mode(
+    #         created_role.name
+    #     )
+
+    #     if maintenance_cmd.success is False:
+    #         self.module.fail_json(
+    #             msg=f"Unable to set Maintenance mode to '{self.maintenance}': {maintenance_cmd.result_message}"
+    #         )
+
+    # if self.state in ["started", "restarted"]:
+    #     self.handle_commands(MgmtRoleCommandsResourceApi(self.api_client).start_command(
+    #         body=ApiRoleNameList(items=[created_role.name]),
+    #     ))
+
+    # elif self.state == "stopped":
+    #     self.handle_commands(MgmtRoleCommandsResourceApi(self.api_client).stop_command(
+    #         body=ApiRoleNameList(items=[created_role.name]),
+    #     ))
+
+    # if refresh:
+    #     self.output = parse_role_result(
+    #         self.role_api.read_role(
+    #             self.cluster,
+    #             created_role.name,
+    #             self.service,
+    #             view="full",
+    #         )
+    #     )
+    # else:
+    #     self.output = parse_role_result(created_role)
+
+    def handle_commands(self, commands: ApiBulkCommandList):
+        if commands.errors:
+            error_msg = "\n".join(commands.errors)
+            self.module.fail_json(msg=error_msg)
+
+        for c in commands.items:
+            # Not in parallel, but should only be a single command
+            self.wait_command(c)
+
+
+def main():
+    module = ClouderaManagerMutableModule.ansible_module(
+        argument_spec=dict(
+            cluster_hostname=dict(aliases=["cluster_host"]),
+            cluster_host_id=dict(),
+            maintenance=dict(type="bool", aliases=["maintenance_mode"]),
+            config=dict(type="dict", aliases=["params", "parameters"]),
+            purge=dict(type="bool", default=False),
+            type=dict(required=True),
+            state=dict(
+                default="present",
+                choices=["present", "absent", "restarted", "started", "stopped"],
+            ),
+        ),
+        mutually_exclusive=[
+            ["cluster_hostname", "cluster_host_id"],
+        ],
+        supports_check_mode=True,
+    )
+
+    result = ClouderaManagerServiceRole(module)
+
+    output = dict(
+        changed=result.changed,
+        role=result.output,
+    )
+
+    if module._diff:
+        output.update(diff=result.diff)
+
+    if result.debug:
+        log = result.log_capture.getvalue()
+        output.update(debug=log, debug_lines=log.split("\n"))
+
+    module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cm_service_role_config.py
+++ b/plugins/modules/cm_service_role_config.py
@@ -1,0 +1,322 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = r"""
+module: cm_service_role_config
+short_description: Manage a service role configuration in cluster
+description:
+  - Manage a service role configuration (role-specific) in a cluster.
+author:
+  - "Webster Mudge (@wmudge)"
+requirements:
+  - cm-client
+options:
+  name:
+    description:
+      - A Cloudera Manager Service role name to manage.
+      - One of C(name) or C(type) is required.
+    type: str
+    aliases:
+      - role_name
+      - role
+  type:
+    description:
+      - A Cloudera Manager Service role type to manage.
+      - One of C(name) or C(type) is required.
+    type: str
+    aliases:
+      - role_type
+  parameters:
+    description:
+      - The role-specific configuration to set, i.e. role overrides.
+      - To unset a parameter, use C(None) as the value.
+    type: dict
+    required: yes
+    aliases:
+      - params
+  purge:
+    description:
+      - Flag for whether the declared parameters should append or overwrite any existing parameters.
+      - To clear all parameters, set I(parameters={}), i.e. an empty dictionary, and I(purge=True).
+    type: bool
+    default: False
+  view:
+    description:
+      - The view to return.
+    type: str
+    default: summary
+    choices:
+        - summary
+        - full
+extends_documentation_fragment:
+  - ansible.builtin.action_common_attributes
+  - cloudera.cluster.cm_options
+  - cloudera.cluster.cm_endpoint
+  - cloudera.cluster.purge
+  - cloudera.cluster.message
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms: all
+"""
+
+EXAMPLES = r"""
+- name: Update (append) Cloudera manager Service Host Monitor role parameters
+  cloudera.cluster.cm_service_role_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters:
+      a_configuration: "schema://host:port"
+      another_configuration: 234
+
+- name: Reset a Cloudera manager Service Host Monitor role parameter
+  cloudera.cluster.cm_service_role_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    name: "a-non-default-role-name"
+    parameters:
+      more_configuration: None
+
+- name: Update (with purge) Cloudera manager Service Host Monitor role parameters
+  cloudera.cluster.cluster_service_role_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters:
+      config_one: None
+      config_two: ValueTwo
+      config_three: 2345
+
+- name: Reset all Cloudera manager Service Host Monitor role parameters
+  cloudera.cluster.cluster_service_role_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters: {}
+    purge: yes
+"""
+
+RETURN = r"""
+config:
+  description:
+    - List of Cloudera Manager Service role configurations.
+    - Returns the C(summary) view of the resulting configuration.
+  type: list
+  elements: dict
+  returned: always
+  contains:
+    name:
+      description:
+        - The canonical name that identifies this configuration parameter.
+      type: str
+      returned: when supported
+    value:
+      description:
+        - The user-defined value.
+        - When absent, the default value (if any) will be used.
+        - Can also be absent, when enumerating allowed configs.
+      type: str
+      returned: when supported
+    required:
+      description:
+        - Whether this configuration is required for the object.
+        - If any required configuration is not set, operations on the object may not work.
+        - Requires I(full) view.
+      type: bool
+      returned: when supported
+    default:
+      description:
+        - The default value.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    display_name:
+      description:
+        - A user-friendly name of the parameters, as would have been shown in the web UI.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    description:
+      description:
+        - A textual description of the parameter.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    related_name:
+      description:
+        - If applicable, contains the related configuration variable used by the source project.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    sensitive:
+      description:
+        - Whether this configuration is sensitive, i.e. contains information such as passwords, which might affect how the value of this configuration might be shared by the caller.
+      type: bool
+      returned: when supported
+    validate_state:
+      description:
+        - State of the configuration parameter after validation.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    validation_message:
+      description:
+        - A message explaining the parameter's validation state.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    validation_warnings_suppressed:
+      description:
+        - Whether validation warnings associated with this parameter are suppressed.
+        - In general, suppressed validation warnings are hidden in the Cloudera Manager UI.
+        - Configurations that do not produce warnings will not contain this field.
+        - Requires I(full) view.
+      type: bool
+      returned: when supported
+"""
+
+import json
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
+    ClouderaManagerMutableModule,
+    ConfigListUpdates,
+)
+
+from cm_client import MgmtRolesResourceApi
+from cm_client.rest import ApiException
+
+
+class ClouderaManagerServiceRoleConfig(ClouderaManagerMutableModule):
+    def __init__(self, module):
+        super(ClouderaManagerServiceRoleConfig, self).__init__(module)
+
+        # Set the parameters
+        self.name = self.get_param("name")
+        self.type = self.get_param("type")
+        self.params = self.get_param("parameters")
+        self.purge = self.get_param("purge")
+        self.view = self.get_param("view")
+
+        # Initialize the return value
+        self.changed = False
+        self.diff = {}
+        self.config = []
+
+        # Execute the logic
+        self.process()
+
+    @ClouderaManagerMutableModule.handle_process
+    def process(self):
+        refresh = True
+        role_api = MgmtRolesResourceApi(self.api_client)
+
+        try:
+            if self.name is None:
+                role = next(
+                    iter(
+                        [r for r in role_api.read_roles().items if r.type == self.type]
+                    ),
+                    None,
+                )
+                if role is None:
+                    self.module.fail_json(
+                        msg=f"Unable to find Cloudera Manager Service role type '{self.type}"
+                    )
+                else:
+                    self.name = role.name
+
+            # For some reason, the call to read_roles() doesn't retrieve the configuration
+            existing = role_api.read_role_config(self.name)
+        except ApiException as ex:
+            if ex.status == 404:
+                self.module.fail_json(msg=json.loads(ex.body)["message"])
+            else:
+                raise ex
+
+        updates = ConfigListUpdates(existing, self.params, self.purge)
+
+        if updates.changed:
+            self.changed = True
+
+            if self.module._diff:
+                self.diff = updates.diff
+
+            if not self.module.check_mode:
+                self.config = [
+                    p.to_dict()
+                    for p in role_api.update_role_config(
+                        self.name,
+                        message=self.message,
+                        body=updates.config,
+                    ).items
+                ]
+
+                if self.view == "full":
+                    refresh = False
+
+        if refresh:
+            self.config = [
+                p.to_dict()
+                for p in role_api.read_role_config(self.name, view=self.view).items
+            ]
+
+
+def main():
+    module = ClouderaManagerMutableModule.ansible_module(
+        argument_spec=dict(
+            name=dict(aliases=["role_name", "role"]),
+            type=dict(aliases=["role_type"]),
+            parameters=dict(type="dict", required=True, aliases=["params"]),
+            purge=dict(type="bool", default=False),
+            view=dict(
+                default="summary",
+                choices=["summary", "full"],
+            ),
+        ),
+        required_one_of=[
+            ["name", "type"],
+        ],
+        supports_check_mode=True,
+    )
+
+    result = ClouderaManagerServiceRoleConfig(module)
+
+    output = dict(
+        changed=result.changed,
+        config=result.config,
+    )
+
+    if module._diff:
+        output.update(diff=result.diff)
+
+    if result.debug:
+        log = result.log_capture.getvalue()
+        output.update(debug=log, debug_lines=log.split("\n"))
+
+    module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cm_service_role_config_group.py
+++ b/plugins/modules/cm_service_role_config_group.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = r"""
+module: cm_service_role_config_group
+short_description: Manage a Cloudera Manager Service role config group.
+description:
+  - Manage a Cloudera Manager Service role config group.
+author:
+  - "Webster Mudge (@wmudge)"
+requirements:
+  - cm-client
+options:
+  type:
+    description:
+      - The role type defining the role config group.
+    type: str
+    required: True
+    aliases:
+      - role_type
+  display_name:
+    description:
+      - The display name for this role config group in the Cloudera Manager UI.
+  config:
+    description:
+      - The role configuration to set.
+      - To unset a parameter, use C(None) as the value.
+    type: dict
+    aliases:
+      - params
+      - parameters
+  purge:
+    description:
+      - Flag indicating whether to reset configuration parameters to only the declared entries.
+    type: bool
+    default: False
+extends_documentation_fragment:
+  - cloudera.cluster.cm_options
+  - cloudera.cluster.cm_endpoint
+  - cloudera.cluster.message
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms: all
+"""
+
+EXAMPLES = r"""
+- name: Update the configuration of a Cloudera Manager Service role config group
+  cloudera.cluster.cm_service_role_config_group:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters:
+      some_parameter: True
+
+- name: Update the configuration of a Cloudera Manager Service role config group, purging undeclared parameters
+  cloudera.cluster.cm_service_role_config_group:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters:
+      another_parameter: 3456
+    purge: yes
+
+- name: Reset the configuration of a Cloudera Manager Service role config group
+  cloudera.cluster.cm_service_role_config_group:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters: {}
+    purge: yes
+
+- name: Set the display name of a Cloudera Manager Service role config group
+  cloudera.cluster.cm_service_role_config_group:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    display_name: A new name
+"""
+
+RETURN = r"""
+role_config_group:
+  description:
+    - A Cloudera Manager Service role config group.
+  type: dict
+  returned: always
+  contains:
+    name:
+      description:
+        - The unique name of this role config group.
+      type: str
+      returned: always
+    role_type:
+      description:
+        - The type of the roles in this group.
+      type: str
+      returned: always
+    base:
+      description:
+        - Flag indicating whether this is a base group.
+      type: bool
+      returned: always
+    display_name:
+      description:
+        - A user-friendly name of the role config group, as would have been shown in the web UI.
+      type: str
+      returned: when supported
+    service_name:
+      description:
+        - The service name associated with this role config group.
+      type: str
+      returned: always
+    role_names:
+      description:
+        - List of role names associated with this role config group.
+      type: list
+      elements: str
+      returned: when supported
+    config:
+      description:
+        - List of configurations.
+      type: list
+      elements: dict
+      returned: always
+      contains:
+        name:
+          description:
+            - The canonical name that identifies this configuration parameter.
+          type: str
+          returned: when supported
+        value:
+          description:
+            - The user-defined value.
+            - When absent, the default value (if any) will be used.
+            - Can also be absent, when enumerating allowed configs.
+          type: str
+          returned: when supported
+        required:
+          description:
+            - Whether this configuration is required for the object.
+            - If any required configuration is not set, operations on the object may not work.
+            - Requires I(full) view.
+          type: bool
+          returned: when supported
+        default:
+          description:
+            - The default value.
+            - Requires I(full) view.
+          type: str
+          returned: when supported
+        display_name:
+          description:
+            - A user-friendly name of the parameters, as would have been shown in the web UI.
+            - Requires I(full) view.
+          type: str
+          returned: when supported
+        description:
+          description:
+            - A textual description of the parameter.
+            - Requires I(full) view.
+          type: str
+          returned: when supported
+        related_name:
+          description:
+            - If applicable, contains the related configuration variable used by the source project.
+            - Requires I(full) view.
+          type: str
+          returned: when supported
+        sensitive:
+          description:
+            - Whether this configuration is sensitive, i.e. contains information such as passwords, which might affect how the value of this configuration might be shared by the caller.
+          type: bool
+          returned: when supported
+        validate_state:
+          description:
+            - State of the configuration parameter after validation.
+            - Requires I(full) view.
+          type: str
+          returned: when supported
+        validation_message:
+          description:
+            - A message explaining the parameter's validation state.
+            - Requires I(full) view.
+          type: str
+          returned: when supported
+        validation_warnings_suppressed:
+          description:
+            - Whether validation warnings associated with this parameter are suppressed.
+            - In general, suppressed validation warnings are hidden in the Cloudera Manager UI.
+            - Configurations that do not produce warnings will not contain this field.
+            - Requires I(full) view.
+          type: bool
+          returned: when supported
+"""
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
+    ClouderaManagerMutableModule,
+    ConfigListUpdates,
+)
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
+    BaseRoleConfigGroupDiscoveryException,
+    parse_role_config_group_result,
+    get_mgmt_base_role_config_group,
+)
+
+from cm_client import (
+    ApiRoleConfigGroup,
+    MgmtRoleConfigGroupsResourceApi,
+    MgmtServiceResourceApi,
+)
+from cm_client.rest import ApiException
+
+
+class ClouderaManagerServiceRoleConfigGroup(ClouderaManagerMutableModule):
+    def __init__(self, module):
+        super(ClouderaManagerServiceRoleConfigGroup, self).__init__(module)
+
+        # Set the parameters
+        self.type = self.get_param("type")
+        self.display_name = self.get_param("display_name")
+        self.config = self.get_param("config", default=dict())
+        self.purge = self.get_param("purge")
+
+        # Initialize the return value
+        self.changed = False
+        self.diff = dict(before=dict(), after=dict())
+        self.output = {}
+
+        # Execute the logic
+        self.process()
+
+    @ClouderaManagerMutableModule.handle_process
+    def process(self):
+        # Confirm that CMS is present
+        try:
+            MgmtServiceResourceApi(self.api_client).read_service()
+        except ApiException as ex:
+            if ex.status == 404:
+                self.module.fail_json(msg="Cloudera Management Service does not exist")
+            else:
+                raise ex
+
+        rcg_api = MgmtRoleConfigGroupsResourceApi(self.api_client)
+
+        # Retrieve the base RCG (the _only_ RCG for CMS roles)
+        try:
+            existing = get_mgmt_base_role_config_group(self.api_client, self.type)
+        except ApiException as ex:
+            if ex.status != 404:
+                raise ex
+        except BaseRoleConfigGroupDiscoveryException as be:
+            self.module.fail_json(
+                msg=f"Unable to find Cloudera Manager Service base role config group for role type '{self.type}'"
+            )
+
+        payload = ApiRoleConfigGroup()
+
+        # Update display name
+        if self.display_name and self.display_name != existing.display_name:
+            self.changed = True
+
+            if self.module._diff:
+                self.diff["before"].update(display_name=existing.display_name)
+                self.diff["after"].update(display_name=self.display_name)
+
+            payload.display_name = self.display_name
+
+        # Reconcile configurations
+        if self.config or self.purge:
+            updates = ConfigListUpdates(existing.config, self.config, self.purge)
+
+            if updates.changed:
+                self.changed = True
+
+                if self.module._diff:
+                    self.diff["before"].update(config=updates.diff["before"])
+                    self.diff["after"].update(config=updates.diff["after"])
+
+                payload.config = updates.config
+
+        # Execute changes if needed
+        if self.changed and not self.module.check_mode:
+            self.output = parse_role_config_group_result(
+                rcg_api.update_role_config_group(
+                    existing.name,
+                    message=self.message,
+                    body=payload,
+                )
+            )
+        else:
+            self.output = parse_role_config_group_result(existing)
+
+        # Report on any role associations
+        self.output.update(
+            role_names=[r.name for r in rcg_api.read_roles(existing.name).items]
+        )
+
+
+def main():
+    module = ClouderaManagerMutableModule.ansible_module(
+        argument_spec=dict(
+            display_name=dict(),
+            type=dict(required=True, aliases=["role_type"]),
+            config=dict(type="dict", aliases=["params", "parameters"]),
+            purge=dict(type="bool", default=False),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = ClouderaManagerServiceRoleConfigGroup(module)
+
+    output = dict(
+        changed=result.changed,
+        role_config_group=result.output,
+    )
+
+    if module._diff:
+        output.update(diff=result.diff)
+
+    if result.debug:
+        log = result.log_capture.getvalue()
+        output.update(debug=log, debug_lines=log.split("\n"))
+
+    module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cm_service_role_config_group_config.py
+++ b/plugins/modules/cm_service_role_config_group_config.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = r"""
+module: cm_service_role_config_group_config
+short_description: Manage the configuration of a Cloudera Manager Service role config group.
+description:
+  - Manage the configuration details of a role config group of the Cloudera Manager Service.
+author:
+  - "Webster Mudge (@wmudge)"
+requirements:
+  - cm-client
+options:
+  name:
+    description:
+      - A role config group name to manage.
+      - One of C(name) or C(type) is required.
+    type: str
+    aliases:
+      - role_config_group
+  type:
+    description:
+      - The role type of the role config group to manage.
+      - Retrieves the default role config group for the given role type.
+      - One of C(name) or C(type) is required.
+    type: str
+    aliases:
+      - role_type
+  parameters:
+    description:
+      - The role configuration to set.
+      - To unset a parameter, use C(None) as the value.
+    type: dict
+    required: yes
+    aliases:
+      - params
+  view:
+    description:
+      - The view to materialize.
+    type: str
+    default: summary
+    choices:
+        - summary
+        - full
+extends_documentation_fragment:
+  - cloudera.cluster.cm_options
+  - cloudera.cluster.cm_endpoint
+  - cloudera.cluster.purge
+  - cloudera.cluster.message
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms: all
+"""
+
+EXAMPLES = r"""
+- name: Update (append) several role config group parameters for a Cloudera Manager Service role type
+  cloudera.cluster.cm_service_role_config_group_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters:
+      a_configuration: "schema://host:port"
+      another_configuration: 234
+
+- name: Reset a role config group parameter for a Cloudera Manager Service role type
+  cloudera.cluster.cm_service_role_config_group_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters:
+      some_conf: None
+
+- name: Update (purge) role config group parameters (by name) for a Cloudera Manager Service role
+  cloudera.cluster.service_role_config_group_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    name: "a-non-default-rcg"
+    parameters:
+      config_one: ValueOne
+      config_two: 4567
+    purge: yes
+
+- name: Reset all role config group parameters for a Cloudera Manager Service role type
+  cloudera.cluster.service_role_config_group_config:
+    host: example.cloudera.com
+    username: "jane_smith"
+    password: "S&peR4Ec*re"
+    type: HOSTMONITOR
+    parameters: {}
+    purge: yes
+"""
+
+RETURN = r"""
+config:
+  description:
+    - List of configurations for a Cloudera Manager Service role config group.
+  type: list
+  elements: dict
+  returned: always
+  contains:
+    name:
+      description:
+        - The canonical name that identifies this configuration parameter.
+      type: str
+      returned: when supported
+    value:
+      description:
+        - The user-defined value.
+        - When absent, the default value (if any) will be used.
+        - Can also be absent, when enumerating allowed configs.
+      type: str
+      returned: when supported
+    required:
+      description:
+        - Whether this configuration is required for the object.
+        - If any required configuration is not set, operations on the object may not work.
+        - Requires I(full) view.
+      type: bool
+      returned: when supported
+    default:
+      description:
+        - The default value.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    display_name:
+      description:
+        - A user-friendly name of the parameters, as would have been shown in the web UI.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    description:
+      description:
+        - A textual description of the parameter.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    related_name:
+      description:
+        - If applicable, contains the related configuration variable used by the source project.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    sensitive:
+      description:
+        - Whether this configuration is sensitive, i.e. contains information such as passwords, which might affect how the value of this configuration might be shared by the caller.
+      type: bool
+      returned: when supported
+    validate_state:
+      description:
+        - State of the configuration parameter after validation.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    validation_message:
+      description:
+        - A message explaining the parameter's validation state.
+        - Requires I(full) view.
+      type: str
+      returned: when supported
+    validation_warnings_suppressed:
+      description:
+        - Whether validation warnings associated with this parameter are suppressed.
+        - In general, suppressed validation warnings are hidden in the Cloudera Manager UI.
+        - Configurations that do not produce warnings will not contain this field.
+        - Requires I(full) view.
+      type: bool
+      returned: when supported
+"""
+
+import json
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
+    ClouderaManagerMutableModule,
+    ConfigListUpdates,
+)
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
+    BaseRoleConfigGroupDiscoveryException,
+    get_mgmt_base_role_config_group,
+)
+
+from cm_client import MgmtRoleConfigGroupsResourceApi
+from cm_client.rest import ApiException
+
+
+class ClouderaManagerServiceRoleConfigGroupConfig(ClouderaManagerMutableModule):
+    def __init__(self, module):
+        super(ClouderaManagerServiceRoleConfigGroupConfig, self).__init__(module)
+
+        # Set the parameters
+        self.name = self.get_param("name")
+        self.type = self.get_param("type")
+        self.params = self.get_param("parameters")
+        self.purge = self.get_param("purge")
+        self.view = self.get_param("view")
+
+        # Initialize the return values
+        self.changed = False
+        self.diff = {}
+        self.config = []
+
+        # Execute the logic
+        self.process()
+
+    @ClouderaManagerMutableModule.handle_process
+    def process(self):
+        refresh = True
+        rcg_api = MgmtRoleConfigGroupsResourceApi(self.api_client)
+
+        try:
+            if self.name is None:
+                rcg = get_mgmt_base_role_config_group(self.api_client, self.type)
+                self.name = rcg.name
+
+            existing = rcg_api.read_config(self.name)
+        except ApiException as ae:
+            if ae.status == 404:
+                self.module.fail_json(msg=json.loads(ae.body)["message"])
+            else:
+                raise ae
+        except BaseRoleConfigGroupDiscoveryException as be:
+            self.module.fail_json(
+                msg=f"Unable to find Cloudera Manager Service base role config group for role type '{self.type}'"
+            )
+
+        updates = ConfigListUpdates(existing, self.params, self.purge)
+
+        if updates.changed:
+            self.changed = True
+
+            if self.module._diff:
+                self.diff = updates.diff
+
+            if not self.module.check_mode:
+                self.config = [
+                    p.to_dict()
+                    for p in rcg_api.update_config(
+                        self.name,
+                        message=self.message,
+                        body=updates.config,
+                    ).items
+                ]
+
+                if self.view == "full":
+                    refresh = False
+
+        if refresh:
+            self.config = [
+                p.to_dict()
+                for p in rcg_api.read_config(self.name, view=self.view).items
+            ]
+
+
+def main():
+    module = ClouderaManagerMutableModule.ansible_module(
+        argument_spec=dict(
+            name=dict(aliases=["role_config_group"]),
+            type=dict(aliases=["role_type"]),
+            parameters=dict(type="dict", required=True, aliases=["params"]),
+            purge=dict(type="bool", default=False),
+            view=dict(
+                default="summary",
+                choices=["summary", "full"],
+            ),
+        ),
+        required_one_of=[
+            ["name", "type"],
+        ],
+        supports_check_mode=True,
+    )
+
+    result = ClouderaManagerServiceRoleConfigGroupConfig(module)
+
+    output = dict(
+        changed=result.changed,
+        config=result.config,
+    )
+
+    if result.debug:
+        log = result.log_capture.getvalue()
+        output.update(debug=log, debug_lines=log.split("\n"))
+
+    module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/service_role.py
+++ b/plugins/modules/service_role.py
@@ -16,8 +16,10 @@
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     ClouderaManagerMutableModule,
-    parse_role_result,
     resolve_tag_updates,
+)
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_utils import (
+    parse_role_result,
 )
 
 from cm_client import (
@@ -33,6 +35,7 @@ from cm_client import (
     ServicesResourceApi,
 )
 from cm_client.rest import ApiException
+
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/plugins/modules/service_role_config_group.py
+++ b/plugins/modules/service_role_config_group.py
@@ -16,6 +16,9 @@
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     ClouderaManagerMutableModule,
+)
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
     parse_role_config_group_result,
 )
 

--- a/plugins/modules/service_role_config_group_config_info.py
+++ b/plugins/modules/service_role_config_group_config_info.py
@@ -16,7 +16,6 @@
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     ClouderaManagerModule,
-    parse_role_config_group_result,
 )
 
 from cm_client import (
@@ -25,6 +24,7 @@ from cm_client import (
     ServicesResourceApi,
 )
 from cm_client.rest import ApiException
+
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/plugins/modules/service_role_config_group_info.py
+++ b/plugins/modules/service_role_config_group_info.py
@@ -16,6 +16,9 @@
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     ClouderaManagerModule,
+)
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
     parse_role_config_group_result,
 )
 
@@ -25,6 +28,7 @@ from cm_client import (
     ServicesResourceApi,
 )
 from cm_client.rest import ApiException
+
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/plugins/modules/service_role_info.py
+++ b/plugins/modules/service_role_info.py
@@ -18,11 +18,15 @@ import json
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.cm_utils import (
     ClouderaManagerModule,
+)
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_utils import (
     parse_role_result,
 )
 
 from cm_client import ClustersResourceApi, RolesResourceApi, ServicesResourceApi
 from cm_client.rest import ApiException
+
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ markers = [
   "role_config: Prepare role override configurations for tests",
   "role_config_group_config: Prepare role config group configurations for tests",
   "role_config_group: Prepare a role config group for tests.",
+  "role: Prepare a role for tests.",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ filterwarnings = [
 markers = [
   "service_config: Prepare service-wide configurations for tests",
   "role_config: Prepare role override configurations for tests",
+  "role_config_group_config: Prepare role config group configurations for tests",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ filterwarnings = [
   "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
 ]
 markers = [
-  "prepare: Prepare Cloudera Manager and resources for tests",
+  "service_config: Prepare service-wide configurations for tests",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = "Apache-2.0"
 keywords = []
-authors = [
-  { name = "Webster Mudge", email = "wmudge@cloudera.com" },
-]
+authors = [{ name = "Webster Mudge", email = "wmudge@cloudera.com" }]
 classifiers = []
 dependencies = []
+
+[tool.hatch.build.targets.wheel]
+bypass-selection = true
 
 [tool.hatch.version]
 path = "galaxy.yml"
@@ -29,7 +30,7 @@ dependencies = [
   "molecule-plugins",
   "molecule-plugins[ec2]",
   "tox-ansible",
-  "ansible-core<2.17", # For RHEL 8 support
+  "ansible-core<2.17",     # For RHEL 8 support
   "jmespath",
   "cm-client",
 ]
@@ -37,17 +38,17 @@ dependencies = [
 [tool.hatch.envs.lint]
 python = "3.12"
 skip-install = true
-extra-dependencies = [
-  "ansible-lint",
-]
+extra-dependencies = ["ansible-lint"]
 
 [tool.hatch.envs.lint.scripts]
 run = "pre-commit run -a"
 
 [tool.pytest.ini_options]
-testpaths = [
-  "tests",
-]
+# addopts = [
+#     "--lf",
+#     "--nf",
+# ]
+testpaths = ["tests"]
 filterwarnings = [
   "ignore:AnsibleCollectionFinder has already been configured",
   "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,12 @@ testpaths = [
 filterwarnings = [
   "ignore:AnsibleCollectionFinder has already been configured",
   "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
+  "ignore:URLs without a scheme:DeprecationWarning",
+  "ignore:HTTPResponse.getheaders():DeprecationWarning",
 ]
 markers = [
   "service_config: Prepare service-wide configurations for tests",
+  "role_config: Prepare role override configurations for tests",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ markers = [
   "service_config: Prepare service-wide configurations for tests",
   "role_config: Prepare role override configurations for tests",
   "role_config_group_config: Prepare role config group configurations for tests",
+  "role_config_group: Prepare a role config group for tests.",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@
 jmespath
 
 # For cm_service lookup
-cm_client
+cm-client

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -61,7 +61,7 @@ class AnsibleFailJson(Exception):
 def wait_for_command(
     api_client: ApiClient, command: ApiCommand, polling: int = 120, delay: int = 5
 ):
-    """Polls Cloudera Manager to wait for a Command to complete."""
+    """Polls Cloudera Manager to wait for given Command to succeed or fail."""
 
     poll_count = 0
     while command.active:
@@ -90,7 +90,7 @@ def provision_service(
         Exception: _description_
 
     Yields:
-        ApiService: _description_
+        Generator[ApiService]: _description_
     """
 
     api = ServicesResourceApi(api_client)
@@ -132,7 +132,7 @@ def service_wide_config(
         Exception: _description_
 
     Yields:
-        ApiService: _description_
+        Generator[ApiService]: _description_
     """
     service_api = ServicesResourceApi(api_client)
 
@@ -190,6 +190,18 @@ def service_wide_config(
 def provision_cm_role(
     api_client: ApiClient, role_name: str, role_type: str, host_id: str
 ) -> Generator[ApiRole]:
+    """Yield a newly-created Cloudera Manager Service role, deleting the
+       role after use. Use with 'yield from' within a pytest fixture.
+
+    Args:
+        api_client (ApiClient): _description_
+        role_name (str): _description_
+        role_type (str): _description_
+        host_id (str): _description_
+
+    Yields:
+        Generator[ApiRole]: _description_
+    """
     api = MgmtRolesResourceApi(api_client)
 
     role = ApiRole(
@@ -203,7 +215,7 @@ def provision_cm_role(
     api.delete_role(role_name=role_name)
 
 
-def cm_role_config(
+def set_cm_role_config(
     api_client: ApiClient, role: ApiRole, params: dict, message: str
 ) -> Generator[ApiRole]:
     """Update a role configuration for a given role. Yields the
@@ -220,7 +232,7 @@ def cm_role_config(
         Exception: _description_
 
     Yields:
-        ApiRole: _description_
+        Generator[ApiRole]: _description_
     """
     role_api = MgmtRolesResourceApi(api_client)
 
@@ -273,11 +285,10 @@ def set_cm_role_config_group(
     update: ApiRoleConfigGroup,
     message: str,
 ) -> Generator[ApiRoleConfigGroup]:
-    """
-    Update a configuration for a given Cloudera Manager Service role config group.
-    Yields the role config group and upon returning control, will reset the
-    configuration to its prior state.
-    Use with 'yield from' within a pytest fixture.
+    """Update a configuration for a given Cloudera Manager Service role config group.
+       Yields the role config group and upon returning control, will reset the
+       configuration to its prior state.
+       Use with 'yield from' within a pytest fixture.
 
     Args:
         api_client (ApiClient): CM API client
@@ -286,7 +297,7 @@ def set_cm_role_config_group(
         message (str): Transaction descriptor; will be appended with '::[re]set'
 
     Yields:
-        ApiRoleConfigGroup: The updated Role Config Group
+        Generator[ApiRoleConfigGroup]: The updated Role Config Group
     """
     rcg_api = MgmtRoleConfigGroupsResourceApi(api_client)
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -267,68 +267,35 @@ def cm_role_config(
     )
 
 
-def set_cm_role_config_group_config(
+def set_cm_role_config_group(
     api_client: ApiClient,
     role_config_group: ApiRoleConfigGroup,
-    params: dict,
+    update: ApiRoleConfigGroup,
     message: str,
 ) -> Generator[ApiRoleConfigGroup]:
-    """Update a configuration for a given Cloudera Manager Service role config group.
-       Yields the role config group, resetting the configuration to its prior state.
-       Use with 'yield from' within a pytest fixture.
+    """
+    Update a configuration for a given Cloudera Manager Service role config group.
+    Yields the role config group and upon returning control, will reset the
+    configuration to its prior state.
+    Use with 'yield from' within a pytest fixture.
 
     Args:
-        api_client (ApiClient): _description_
-        role_config_group (ApiRoleConfigGroup): _description_
-        params (dict): _description_
-        message (str): _description_
-
-    Raises:
-        Exception: _description_
+        api_client (ApiClient): CM API client
+        role_config_group (ApiRoleConfigGroup): The Role Config Group to manage
+        update (ApiRoleConfigGroup): The state to set
+        message (str): Transaction descriptor; will be appended with '::[re]set'
 
     Yields:
-        ApiRoleConfigGroup: _description_
+        ApiRoleConfigGroup: The updated Role Config Group
     """
     rcg_api = MgmtRoleConfigGroupsResourceApi(api_client)
 
-    # Retrieve all of the pre-setup configurations
-    pre = rcg_api.read_config(role_config_group.name)
+    pre = rcg_api.read_role_config_group(role_config_group.name)
 
-    # Set the test configurations
-    # Do so serially, since a failed update due to defaults (see ApiException) will cause remaining
-    # configuration entries to not run. Long-term solution is to check-and-set, which is
-    # what the Ansible modules do...
-    for k, v in params.items():
-        try:
-            rcg_api.update_config(
-                role_config_group.name,
-                message=f"{message}::set",
-                body=ApiConfigList(items=[ApiConfig(name=k, value=v)]),
-            )
-        except ApiException as ae:
-            if ae.status != 400 or "delete with template" not in str(ae.body):
-                raise Exception(str(ae))
-
-    # Yield the targeted role
-    yield rcg_api.read_role_config_group(role_config_group.name)
-
-    # Retrieve all of the post-setup configurations
-    post = rcg_api.read_config(role_config_group.name)
-
-    # Reconcile the configurations
-    pre_set = set([c.name for c in pre.items])
-
-    reconciled = pre.items.copy()
-    reconciled.extend(
-        [
-            ApiConfig(name=k.name, value=None)
-            for k in post.items
-            if k.name not in pre_set
-        ]
+    yield rcg_api.update_role_config_group(
+        role_config_group.name, message=f"{message}::set", body=update
     )
 
-    rcg_api.update_config(
-        role_config_group.name,
-        message=f"{message}::reset",
-        body=ApiConfigList(items=reconciled),
+    rcg_api.update_role_config_group(
+        role_config_group.name, message=f"{message}::reset", body=pre
     )

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -22,11 +22,15 @@ from cm_client import (
     ApiCluster,
     ApiCommand,
     ApiConfig,
+    ApiConfigList,
+    ApiRole,
+    ApiRoleList,
     ApiService,
     ApiServiceConfig,
     ApiServiceList,
     ClustersResourceApi,
     CommandsResourceApi,
+    MgmtRolesResourceApi,
     ServicesResourceApi,
 )
 from cm_client.rest import ApiException
@@ -178,4 +182,84 @@ def service_wide_config(
         service_name=service.name,
         message=f"{message}::reset",
         body=ApiServiceConfig(items=reconciled),
+    )
+
+
+def provision_cm_role(
+    api_client: ApiClient, role_name: str, role_type: str, host_id: str
+) -> Generator[ApiRole]:
+    api = MgmtRolesResourceApi(api_client)
+
+    role = ApiRole(
+        name=role_name,
+        type=role_type,
+        host_ref=dict(hostId=host_id),
+    )
+
+    yield next(iter(api.create_roles(body=ApiRoleList(items=[role])).items), None)
+
+    api.delete_role(role_name=role_name)
+
+
+def cm_role_config(
+    api_client: ApiClient, role: ApiRole, params: dict, message: str
+) -> Generator[ApiRole]:
+    """Update a role configuration for a given role. Yields the
+       role, resetting the configuration to its prior state. Use with
+       'yield from' within a pytest fixture.
+
+    Args:
+        api_client (ApiClient): _description_
+        role (ApiRole): _description_
+        params (dict): _description_
+        message (str): _description_
+
+    Raises:
+        Exception: _description_
+
+    Yields:
+        ApiRole: _description_
+    """
+    role_api = MgmtRolesResourceApi(api_client)
+
+    # Retrieve all of the pre-setup configurations
+    pre = role_api.read_role_config(role.name)
+
+    # Set the test configurations
+    # Do so serially, since a failed update due to defaults (see ApiException) will cause remaining
+    # configuration entries to not run. Long-term solution is to check-and-set, which is
+    # what the Ansible modules do...
+    for k, v in params.items():
+        try:
+            role_api.update_role_config(
+                role_name=role.name,
+                message=f"{message}::set",
+                body=ApiConfigList(items=[ApiConfig(name=k, value=v)]),
+            )
+        except ApiException as ae:
+            if ae.status != 400 or "delete with template" not in str(ae.body):
+                raise Exception(str(ae))
+
+    # Yield the targeted role
+    yield role_api.read_role(role_name=role.name)
+
+    # Retrieve all of the post-setup configurations
+    post = role_api.read_role_config(role_name=role.name)
+
+    # Reconcile the configurations
+    pre_set = set([c.name for c in pre.items])
+
+    reconciled = pre.items.copy()
+    reconciled.extend(
+        [
+            ApiConfig(name=k.name, value=None)
+            for k in post.items
+            if k.name not in pre_set
+        ]
+    )
+
+    role_api.update_role_config(
+        role_name=role.name,
+        message=f"{message}::reset",
+        body=ApiConfigList(items=reconciled),
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,6 +26,7 @@ import string
 import sys
 import yaml
 
+from collections.abc import Generator
 from pathlib import Path
 
 from cm_client import (
@@ -40,6 +41,7 @@ from cm_client import (
     ClustersResourceApi,
     Configuration,
     HostsResourceApi,
+    MgmtRolesResourceApi,
     MgmtServiceResourceApi,
     ParcelResourceApi,
     ParcelsResourceApi,
@@ -250,7 +252,7 @@ def base_cluster(cm_api_client, request):
 
 
 @pytest.fixture(scope="session")
-def cms(cm_api_client, request):
+def cms(cm_api_client, request) -> Generator[ApiService]:
     """Provisions Cloudera Manager Service."""
 
     api = MgmtServiceResourceApi(cm_api_client)
@@ -275,7 +277,7 @@ def cms(cm_api_client, request):
 
 
 @pytest.fixture(scope="function")
-def cms_service_config(cm_api_client, cms, request):
+def cms_config(cm_api_client, cms, request) -> Generator[ApiService]:
     """Configures service-wide configurations for the Cloudera Manager Service"""
 
     marker = request.node.get_closest_marker("service_config")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,6 +70,7 @@ from ansible_collections.cloudera.cluster.tests.unit import (
     AnsibleFailJson,
     AnsibleExitJson,
     provision_cm_role,
+    set_cm_role_config,
     set_cm_role_config_group,
 )
 
@@ -379,7 +380,7 @@ def host_monitor_config(cm_api_client, host_monitor, request) -> Generator[ApiRo
     if marker is None:
         raise Exception("No role_config marker found.")
 
-    yield from cm_role_config(
+    yield from set_cm_role_config(
         api_client=cm_api_client,
         role=host_monitor,
         params=marker.args[0],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -295,7 +295,7 @@ def cms_service_config(cm_api_client, cms, request):
     for k, v in marker.args[0].items():
         try:
             api.update_service_config(
-                message=f"{request.node.name}::set",
+                message=f"{Path(request.node.parent.name).stem}::{request.node.name}::set",
                 body=ApiServiceConfig(items=[ApiConfig(name=k, value=v)]),
             )
         except ApiException as ae:
@@ -321,6 +321,6 @@ def cms_service_config(cm_api_client, cms, request):
     )
 
     api.update_service_config(
-        message=f"{request.node.name}::reset",
+        message=f"{Path(request.node.parent.name).stem}::{request.node.name}::reset",
         body=ApiServiceConfig(items=reconciled),
     )

--- a/tests/unit/plugins/modules/cm_service/test_cm_service.py
+++ b/tests/unit/plugins/modules/cm_service/test_cm_service.py
@@ -38,7 +38,7 @@ def test_minimal(conn, module_args, cms):
 
 
 @pytest.mark.service_config(dict(log_event_retry_frequency=10))
-def test_set_parameters(conn, module_args, cms_service_config):
+def test_set_parameters(conn, module_args, cms_config):
     module_args(
         {
             **conn,
@@ -76,7 +76,7 @@ def test_set_parameters(conn, module_args, cms_service_config):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=True, log_event_retry_frequency=10)
 )
-def test_unset_parameters(conn, module_args, cms_service_config):
+def test_unset_parameters(conn, module_args, cms_config):
     module_args(
         {
             **conn,
@@ -110,7 +110,7 @@ def test_unset_parameters(conn, module_args, cms_service_config):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=True, log_event_retry_frequency=10)
 )
-def test_set_parameters_with_purge(conn, module_args, cms_service_config):
+def test_set_parameters_with_purge(conn, module_args, cms_config):
     module_args(
         {
             **conn,
@@ -147,7 +147,7 @@ def test_set_parameters_with_purge(conn, module_args, cms_service_config):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=True, log_event_retry_frequency=10)
 )
-def test_purge_all_parameters(conn, module_args, cms_service_config):
+def test_purge_all_parameters(conn, module_args, cms_config):
     module_args(
         {
             **conn,

--- a/tests/unit/plugins/modules/cm_service_config/test_cm_service_config.py
+++ b/tests/unit/plugins/modules/cm_service_config/test_cm_service_config.py
@@ -54,7 +54,7 @@ def test_present_invalid_parameter(conn, module_args):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=False, log_event_retry_frequency=10)
 )
-def test_set_parameters(conn, module_args, cms_service_config):
+def test_set_parameters(conn, module_args, cms_config):
     module_args(
         {
             **conn,
@@ -86,7 +86,7 @@ def test_set_parameters(conn, module_args, cms_service_config):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=True, log_event_retry_frequency=10)
 )
-def test_unset_parameters(conn, module_args, cms_service_config):
+def test_unset_parameters(conn, module_args, cms_config):
     module_args(
         {
             **conn,
@@ -114,7 +114,7 @@ def test_unset_parameters(conn, module_args, cms_service_config):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=True, log_event_retry_frequency=10)
 )
-def test_set_parameters_with_purge(conn, module_args, cms_service_config):
+def test_set_parameters_with_purge(conn, module_args, cms_config):
     module_args(
         {
             **conn,
@@ -145,7 +145,7 @@ def test_set_parameters_with_purge(conn, module_args, cms_service_config):
 @pytest.mark.service_config(
     dict(mgmt_emit_sensitive_data_in_stderr=True, log_event_retry_frequency=10)
 )
-def test_purge_all_parameters(conn, module_args, cms_service_config):
+def test_purge_all_parameters(conn, module_args, cms_config):
     module_args(
         {
             **conn,

--- a/tests/unit/plugins/modules/cm_service_config/test_cm_service_config.py
+++ b/tests/unit/plugins/modules/cm_service_config/test_cm_service_config.py
@@ -38,10 +38,12 @@ def test_missing_required(conn, module_args):
 
 
 def test_present_invalid_parameter(conn, module_args):
-    conn.update(
-        parameters=dict(example="Example"),
+    module_args(
+        {
+            **conn,
+            "parameters": dict(example="Example"),
+        }
     )
-    module_args(conn)
 
     with pytest.raises(
         AnsibleFailJson, match="Unknown configuration attribute 'example'"

--- a/tests/unit/plugins/modules/cm_service_role/test_cm_service_role.py
+++ b/tests/unit/plugins/modules/cm_service_role/test_cm_service_role.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+# Copyright 2025 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ from cm_client import (
     ApiConfig,
     ApiConfigList,
     ApiRole,
+    ApiRoleList,
+    ApiRoleState,
     ClustersResourceApi,
     MgmtRolesResourceApi,
 )
@@ -36,45 +38,141 @@ from ansible_collections.cloudera.cluster.plugins.modules import cm_service_role
 from ansible_collections.cloudera.cluster.tests.unit import (
     AnsibleExitJson,
     AnsibleFailJson,
-    provision_cm_role,
-    cm_role_config,
+    set_cm_role,
+)
+from ansible_collections.cloudera.cluster.plugins.module_utils.host_utils import (
+    get_host_ref,
+)
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_utils import (
+    get_mgmt_roles,
 )
 
 LOG = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="function")
+def target_cm_role(cm_api_client, cms, base_cluster, request) -> Generator[ApiRole]:
+    marker = request.node.get_closest_marker("role")
+
+    if marker is None:
+        role = ApiRole(
+            type="HOSTMONITOR",
+        )
+    else:
+        role = marker.args[0]
+        role.type = "HOSTMONITOR"
+
+    yield from set_cm_role(cm_api_client, base_cluster, role)
+
+
+@pytest.fixture(scope="function")
+def target_cm_role_cleared(
+    cm_api_client, base_cluster, host_monitor_cleared, request
+) -> Generator[ApiRole]:
+    marker = request.node.get_closest_marker("role")
+
+    if marker is None:
+        role = ApiRole(
+            type="HOSTMONITOR",
+        )
+    else:
+        role = marker.args[0]
+        role.type = "HOSTMONITOR"
+
+    role_api = MgmtRolesResourceApi(cm_api_client)
+
+    if not role.host_ref:
+        cluster_api = ClustersResourceApi(cm_api_client)
+
+        # Get first host of the cluster
+        hosts = cluster_api.list_hosts(cluster_name=base_cluster.name)
+
+        if not hosts.items:
+            raise Exception(
+                "No available hosts to assign the Cloudera Manager Service role."
+            )
+
+        role.host_ref = get_host_ref(cm_api_client, host_id=hosts.items[0].host_id)
+
+    # Create and yield the role under test
+    current_role = next(
+        iter(role_api.create_roles(body=ApiRoleList(items=[role])).items), None
+    )
+    current_role.config = role_api.read_role_config(role_name=current_role.name)
+
+    yield current_role
+
+    # Clear out any remaining roles
+    remaining_roles = get_mgmt_roles(cm_api_client, "HOSTMONITOR")
+
+    for r in remaining_roles.items:
+        role_api.delete_role(role_name=r.name)
+
+
 def test_missing_required(conn, module_args):
     module_args(conn)
 
-    with pytest.raises(AnsibleFailJson, match="parameters"):
+    with pytest.raises(AnsibleFailJson, match="type"):
         cm_service_role.main()
 
 
-def test_missing_required_if(conn, module_args):
-    module_args(
-        {
-            **conn,
-            "parameters": dict(),
-        }
-    )
-
-    with pytest.raises(AnsibleFailJson, match="name, type"):
-        cm_service_role.main()
-
-
-def test_present_invalid_parameter(conn, module_args, host_monitor):
-    module_args(
-        {
-            **conn,
-            "role": host_monitor.name,
-            "parameters": dict(example="Example"),
-        }
-    )
+def test_mutually_exclusive(conn, module_args):
+    module_args({**conn, "cluster_hostname": "hostname", "cluster_host_id": "host_id"})
 
     with pytest.raises(
-        AnsibleFailJson, match="Unknown configuration attribute 'example'"
+        AnsibleFailJson,
+        match="parameters are mutually exclusive: cluster_hostname|cluster_host_id",
     ):
         cm_service_role.main()
+
+
+@pytest.mark.role(ApiRole())
+def test_relocate_host(
+    conn, module_args, cm_api_client, base_cluster, target_cm_role_cleared, request
+):
+    cluster_api = ClustersResourceApi(cm_api_client)
+
+    # Get second host of the cluster
+    hosts = cluster_api.list_hosts(cluster_name=base_cluster.name)
+
+    if not hosts.items:
+        raise Exception(
+            "No available hosts to assign the Cloudera Manager Service role."
+        )
+    filtered_hosts = [
+        h for h in hosts.items if h.host_id != target_cm_role_cleared.host_ref.host_id
+    ]
+
+    if len(filtered_hosts) < 1:
+        raise Exception(
+            "Not enough hosts to reassign the Cloudera Manager Service role."
+        )
+
+    module_args(
+        {
+            **conn,
+            "type": target_cm_role_cleared.type,
+            "cluster_hostname": filtered_hosts[0].hostname,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = filtered_hosts[0].host_id
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert expected == e.value.role["host_id"]
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == False
+    assert expected == e.value.role["host_id"]
 
 
 @pytest.mark.role(
@@ -87,19 +185,19 @@ def test_present_invalid_parameter(conn, module_args, host_monitor):
         )
     )
 )
-def test_set_parameters(conn, module_args, host_monitor_state, request):
+def test_set_config(conn, module_args, target_cm_role, request):
     module_args(
         {
             **conn,
-            "type": host_monitor_state.type,
-            "config": dict(mgmt_num_descriptor_fetch_tries=32),
+            "type": target_cm_role.type,
+            "config": dict(mgmt_num_descriptor_fetch_tries=55),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
             # _ansible_diff=True,
         }
     )
 
-    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+    expected = dict(mgmt_num_descriptor_fetch_tries="55", process_start_secs="21")
 
     with pytest.raises(AnsibleExitJson) as e:
         cm_service_role.main()
@@ -115,104 +213,58 @@ def test_set_parameters(conn, module_args, host_monitor_state, request):
     assert expected.items() <= e.value.role["config"].items()
 
 
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
-)
-def test_set_parameters_role_type(conn, module_args, host_monitor_config, request):
-    module_args(
-        {
-            **conn,
-            "role_type": host_monitor_config.type,
-            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
-            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
-            # _ansible_check_mode=True,
-            # _ansible_diff=True,
-        }
+@pytest.mark.role(
+    ApiRole(
+        config=ApiConfigList(
+            items=[
+                ApiConfig("mgmt_num_descriptor_fetch_tries", 12),
+                ApiConfig("process_start_secs", 22),
+            ]
+        )
     )
-
-    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
-
-    with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
-
-    assert e.value.changed == True
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
-
-    # Idempotency
-    with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
-
-    assert e.value.changed == False
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
-
-
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
 )
-def test_unset_parameters(conn, module_args, host_monitor_config, request):
+def test_unset_config(conn, module_args, target_cm_role, request):
     module_args(
         {
             **conn,
-            "role": host_monitor_config.name,
-            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "type": target_cm_role.type,
+            "config": dict(mgmt_num_descriptor_fetch_tries=None),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
         }
     )
 
-    expected = dict(process_start_secs="21")
+    expected = dict(process_start_secs="22")
 
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == True
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+    assert expected.items() <= e.value.role["config"].items()
 
     # Idempotency
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == False
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+    assert expected.items() <= e.value.role["config"].items()
 
 
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
-)
-def test_unset_parameters_role_type(conn, module_args, host_monitor_config, request):
-    module_args(
-        {
-            **conn,
-            "type": host_monitor_config.type,
-            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
-            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
-        }
+@pytest.mark.role(
+    ApiRole(
+        config=ApiConfigList(
+            items=[
+                ApiConfig("mgmt_num_descriptor_fetch_tries", 13),
+                ApiConfig("process_start_secs", 23),
+            ]
+        )
     )
-
-    expected = dict(process_start_secs="21")
-
-    with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
-
-    assert e.value.changed == True
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
-
-    # Idempotency
-    with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
-
-    assert e.value.changed == False
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
-
-
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
 )
-def test_set_parameters_with_purge(conn, module_args, host_monitor_config, request):
+def test_set_config_purge(conn, module_args, target_cm_role, request):
     module_args(
         {
             **conn,
-            "role": host_monitor_config.name,
-            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "type": target_cm_role.type,
+            "config": dict(mgmt_num_descriptor_fetch_tries=33),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -220,65 +272,38 @@ def test_set_parameters_with_purge(conn, module_args, host_monitor_config, reque
         }
     )
 
-    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+    expected = dict(mgmt_num_descriptor_fetch_tries="33")
 
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == True
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+    assert expected.items() <= e.value.role["config"].items()
 
     # Idempotency
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == False
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+    assert expected.items() <= e.value.role["config"].items()
 
 
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
-)
-def test_set_parameters_with_purge_role_type(
-    conn, module_args, host_monitor_config, request
-):
-    module_args(
-        {
-            **conn,
-            "role_type": host_monitor_config.type,
-            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
-            "purge": True,
-            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
-            # _ansible_check_mode=True,
-            # _ansible_diff=True,
-        }
+@pytest.mark.role(
+    ApiRole(
+        config=ApiConfigList(
+            items=[
+                ApiConfig("mgmt_num_descriptor_fetch_tries", 14),
+                ApiConfig("process_start_secs", 24),
+            ]
+        )
     )
-
-    expected = dict(mgmt_num_descriptor_fetch_tries="32")
-
-    with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
-
-    assert e.value.changed == True
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
-
-    # Idempotency
-    with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
-
-    assert e.value.changed == False
-    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
-
-
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
 )
-def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
+def test_set_config_purge_all(conn, module_args, target_cm_role, request):
     module_args(
         {
             **conn,
-            "role": host_monitor_config.name,
-            "parameters": dict(),
+            "type": target_cm_role.type,
+            "config": dict(),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -287,31 +312,26 @@ def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
     )
 
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == True
-    assert len(e.value.config) == 0
+    assert len(e.value.role["config"]) == 0
 
     # Idempotency
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == False
-    assert len(e.value.config) == 0
+    assert len(e.value.role["config"]) == 0
 
 
-@pytest.mark.role_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
-)
-def test_purge_all_parameters_role_type(
-    conn, module_args, host_monitor_config, request
-):
+@pytest.mark.role(ApiRole(maintenance_mode=False))
+def test_maintenance_mode_enabled(conn, module_args, target_cm_role, request):
     module_args(
         {
             **conn,
-            "type": host_monitor_config.type,
-            "parameters": dict(),
-            "purge": True,
+            "type": target_cm_role.type,
+            "maintenance": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
             # _ansible_diff=True,
@@ -319,14 +339,148 @@ def test_purge_all_parameters_role_type(
     )
 
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == True
-    assert len(e.value.config) == 0
+    assert e.value.role["maintenance_mode"] == True
 
     # Idempotency
     with pytest.raises(AnsibleExitJson) as e:
-        cm_service_role_config.main()
+        cm_service_role.main()
 
     assert e.value.changed == False
-    assert len(e.value.config) == 0
+    assert e.value.role["maintenance_mode"] == True
+
+
+@pytest.mark.role(ApiRole(maintenance_mode=True))
+def test_maintenance_mode_disabled(conn, module_args, target_cm_role, request):
+    module_args(
+        {
+            **conn,
+            "type": target_cm_role.type,
+            "maintenance": False,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert e.value.role["maintenance_mode"] == False
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == False
+    assert e.value.role["maintenance_mode"] == False
+
+
+@pytest.mark.role(ApiRole(role_state=ApiRoleState.STOPPED))
+def test_state_started(conn, module_args, target_cm_role, request):
+    module_args(
+        {
+            **conn,
+            "type": target_cm_role.type,
+            "state": "started",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert e.value.role["role_state"] == "STARTED"
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == False
+    assert e.value.role["role_state"] == "STARTED"
+
+
+@pytest.mark.role(ApiRole(role_state=ApiRoleState.STARTED))
+def test_state_started(conn, module_args, target_cm_role, request):
+    module_args(
+        {
+            **conn,
+            "type": target_cm_role.type,
+            "state": "stopped",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert e.value.role["role_state"] == "STOPPED"
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == False
+    assert e.value.role["role_state"] == "STOPPED"
+
+
+@pytest.mark.role(ApiRole(role_state=ApiRoleState.STOPPED))
+def test_state_restarted(conn, module_args, target_cm_role, request):
+    module_args(
+        {
+            **conn,
+            "type": target_cm_role.type,
+            "state": "restarted",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert e.value.role["role_state"] == "STARTED"
+
+    # Idempotency is not possible due to this state
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert e.value.role["role_state"] == "STARTED"
+
+
+def test_state_absent(conn, module_args, target_cm_role_cleared, request):
+    module_args(
+        {
+            **conn,
+            "type": target_cm_role_cleared.type,
+            "state": "absent",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert not e.value.role
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == False
+    assert not e.value.role

--- a/tests/unit/plugins/modules/cm_service_role/test_cm_service_role.py
+++ b/tests/unit/plugins/modules/cm_service_role/test_cm_service_role.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import logging
+import pytest
+
+from collections.abc import Generator
+from pathlib import Path
+
+from cm_client import (
+    ApiConfig,
+    ApiConfigList,
+    ApiRole,
+    ClustersResourceApi,
+    MgmtRolesResourceApi,
+)
+
+from ansible_collections.cloudera.cluster.plugins.modules import cm_service_role
+from ansible_collections.cloudera.cluster.tests.unit import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    provision_cm_role,
+    cm_role_config,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def host_monitor(cm_api_client, cms, request) -> Generator[ApiRole]:
+    api = MgmtRolesResourceApi(cm_api_client)
+
+    hm = next(
+        iter([r for r in api.read_roles().items if r.type == "HOSTMONITOR"]), None
+    )
+
+    if hm is not None:
+        yield hm
+    else:
+        cluster_api = ClustersResourceApi(cm_api_client)
+
+        # Get first host of the cluster
+        hosts = cluster_api.list_hosts(cluster_name=cms.cluster_ref.cluster_name)
+
+        if not hosts.items:
+            raise Exception(
+                "No available hosts to assign the Cloudera Manager Service role."
+            )
+        else:
+            name = Path(request.fixturename).stem
+            yield from provision_cm_role(
+                cm_api_client, name, "HOSTMONITOR", hosts.items[0].hostId
+            )
+
+
+@pytest.fixture(scope="function")
+def host_monitor_config(cm_api_client, host_monitor, request) -> Generator[ApiRole]:
+    marker = request.node.get_closest_marker("role_config")
+
+    if marker is None:
+        raise Exception("No role_config marker found.")
+
+    yield from cm_role_config(
+        api_client=cm_api_client,
+        role=host_monitor,
+        params=marker.args[0],
+        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
+    )
+
+
+def test_missing_required(conn, module_args):
+    module_args(conn)
+
+    with pytest.raises(AnsibleFailJson, match="parameters"):
+        cm_service_role.main()
+
+
+def test_missing_required_if(conn, module_args):
+    module_args(
+        {
+            **conn,
+            "parameters": dict(),
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="name, type"):
+        cm_service_role.main()
+
+
+def test_present_invalid_parameter(conn, module_args, host_monitor):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor.name,
+            "parameters": dict(example="Example"),
+        }
+    )
+
+    with pytest.raises(
+        AnsibleFailJson, match="Unknown configuration attribute 'example'"
+    ):
+        cm_service_role.main()
+
+
+@pytest.mark.role(
+    ApiRole(
+        config=ApiConfigList(
+            items=[
+                ApiConfig("mgmt_num_descriptor_fetch_tries", 11),
+                ApiConfig("process_start_secs", 21),
+            ]
+        )
+    )
+)
+def test_set_parameters(conn, module_args, host_monitor_state, request):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_state.type,
+            "config": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role["config"].items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_role_type(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role_type": host_monitor_config.type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_unset_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_unset_parameters_role_type(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_with_purge(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_with_purge_role_type(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "role_type": host_monitor_config.type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert len(e.value.config) == 0
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert len(e.value.config) == 0
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_purge_all_parameters_role_type(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.type,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert len(e.value.config) == 0
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert len(e.value.config) == 0

--- a/tests/unit/plugins/modules/cm_service_role/test_cm_service_role.py
+++ b/tests/unit/plugins/modules/cm_service_role/test_cm_service_role.py
@@ -43,48 +43,6 @@ from ansible_collections.cloudera.cluster.tests.unit import (
 LOG = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
-def host_monitor(cm_api_client, cms, request) -> Generator[ApiRole]:
-    api = MgmtRolesResourceApi(cm_api_client)
-
-    hm = next(
-        iter([r for r in api.read_roles().items if r.type == "HOSTMONITOR"]), None
-    )
-
-    if hm is not None:
-        yield hm
-    else:
-        cluster_api = ClustersResourceApi(cm_api_client)
-
-        # Get first host of the cluster
-        hosts = cluster_api.list_hosts(cluster_name=cms.cluster_ref.cluster_name)
-
-        if not hosts.items:
-            raise Exception(
-                "No available hosts to assign the Cloudera Manager Service role."
-            )
-        else:
-            name = Path(request.fixturename).stem
-            yield from provision_cm_role(
-                cm_api_client, name, "HOSTMONITOR", hosts.items[0].hostId
-            )
-
-
-@pytest.fixture(scope="function")
-def host_monitor_config(cm_api_client, host_monitor, request) -> Generator[ApiRole]:
-    marker = request.node.get_closest_marker("role_config")
-
-    if marker is None:
-        raise Exception("No role_config marker found.")
-
-    yield from cm_role_config(
-        api_client=cm_api_client,
-        role=host_monitor,
-        params=marker.args[0],
-        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
-    )
-
-
 def test_missing_required(conn, module_args):
     module_args(conn)
 

--- a/tests/unit/plugins/modules/cm_service_role_config/test_cm_service_role_config.py
+++ b/tests/unit/plugins/modules/cm_service_role_config/test_cm_service_role_config.py
@@ -41,48 +41,6 @@ from ansible_collections.cloudera.cluster.tests.unit import (
 LOG = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
-def host_monitor(cm_api_client, cms, request) -> Generator[ApiRole]:
-    api = MgmtRolesResourceApi(cm_api_client)
-
-    hm = next(
-        iter([r for r in api.read_roles().items if r.type == "HOSTMONITOR"]), None
-    )
-
-    if hm is not None:
-        yield hm
-    else:
-        cluster_api = ClustersResourceApi(cm_api_client)
-
-        # Get first host of the cluster
-        hosts = cluster_api.list_hosts(cluster_name=cms.cluster_ref.cluster_name)
-
-        if not hosts.items:
-            raise Exception(
-                "No available hosts to assign the Cloudera Manager Service role."
-            )
-        else:
-            name = Path(request.fixturename).stem
-            yield from provision_cm_role(
-                cm_api_client, name, "HOSTMONITOR", hosts.items[0].hostId
-            )
-
-
-@pytest.fixture(scope="function")
-def host_monitor_config(cm_api_client, host_monitor, request) -> Generator[ApiRole]:
-    marker = request.node.get_closest_marker("role_config")
-
-    if marker is None:
-        raise Exception("No role_config marker found.")
-
-    yield from cm_role_config(
-        api_client=cm_api_client,
-        role=host_monitor,
-        params=marker.args[0],
-        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
-    )
-
-
 def test_missing_required(conn, module_args):
     module_args(conn)
 

--- a/tests/unit/plugins/modules/cm_service_role_config/test_cm_service_role_config.py
+++ b/tests/unit/plugins/modules/cm_service_role_config/test_cm_service_role_config.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import logging
+import pytest
+
+from collections.abc import Generator
+from pathlib import Path
+
+from cm_client import (
+    ApiRole,
+    ClustersResourceApi,
+    MgmtRolesResourceApi,
+)
+
+from ansible_collections.cloudera.cluster.plugins.modules import cm_service_role_config
+from ansible_collections.cloudera.cluster.tests.unit import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    provision_cm_role,
+    cm_role_config,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def host_monitor(cm_api_client, cms, request) -> Generator[ApiRole]:
+    api = MgmtRolesResourceApi(cm_api_client)
+
+    hm = next(
+        iter([r for r in api.read_roles().items if r.type == "HOSTMONITOR"]), None
+    )
+
+    if hm is not None:
+        yield hm
+    else:
+        cluster_api = ClustersResourceApi(cm_api_client)
+
+        # Get first host of the cluster
+        hosts = cluster_api.list_hosts(cluster_name=cms.cluster_ref.cluster_name)
+
+        if not hosts.items:
+            raise Exception(
+                "No available hosts to assign the Cloudera Manager Service role."
+            )
+        else:
+            name = Path(request.fixturename).stem
+            yield from provision_cm_role(
+                cm_api_client, name, "HOSTMONITOR", hosts.items[0].hostId
+            )
+
+
+@pytest.fixture(scope="function")
+def host_monitor_config(cm_api_client, host_monitor, request) -> Generator[ApiRole]:
+    marker = request.node.get_closest_marker("role_config")
+
+    if marker is None:
+        raise Exception("No role_config marker found.")
+
+    yield from cm_role_config(
+        api_client=cm_api_client,
+        role=host_monitor,
+        params=marker.args[0],
+        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
+    )
+
+
+def test_missing_required(conn, module_args):
+    module_args(conn)
+
+    with pytest.raises(AnsibleFailJson, match="parameters"):
+        cm_service_role_config.main()
+
+
+def test_missing_required_if(conn, module_args):
+    module_args(
+        {
+            **conn,
+            "parameters": dict(),
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="name, type"):
+        cm_service_role_config.main()
+
+
+def test_present_invalid_parameter(conn, module_args, host_monitor):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor.name,
+            "parameters": dict(example="Example"),
+        }
+    )
+
+    with pytest.raises(
+        AnsibleFailJson, match="Unknown configuration attribute 'example'"
+    ):
+        cm_service_role_config.main()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_role_type(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role_type": host_monitor_config.type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_unset_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_unset_parameters_role_type(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_with_purge(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_with_purge_role_type(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "role_type": host_monitor_config.type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "role": host_monitor_config.name,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert len(e.value.config) == 0
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert len(e.value.config) == 0
+
+
+@pytest.mark.role_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_purge_all_parameters_role_type(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.type,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == True
+    assert len(e.value.config) == 0
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config.main()
+
+    assert e.value.changed == False
+    assert len(e.value.config) == 0

--- a/tests/unit/plugins/modules/cm_service_role_config/test_cm_service_role_config.py
+++ b/tests/unit/plugins/modules/cm_service_role_config/test_cm_service_role_config.py
@@ -21,21 +21,12 @@ __metaclass__ = type
 import logging
 import pytest
 
-from collections.abc import Generator
 from pathlib import Path
-
-from cm_client import (
-    ApiRole,
-    ClustersResourceApi,
-    MgmtRolesResourceApi,
-)
 
 from ansible_collections.cloudera.cluster.plugins.modules import cm_service_role_config
 from ansible_collections.cloudera.cluster.tests.unit import (
     AnsibleExitJson,
     AnsibleFailJson,
-    provision_cm_role,
-    cm_role_config,
 )
 
 LOG = logging.getLogger(__name__)

--- a/tests/unit/plugins/modules/cm_service_role_config_group/test_cm_service_role_config_group.py
+++ b/tests/unit/plugins/modules/cm_service_role_config_group/test_cm_service_role_config_group.py
@@ -1,0 +1,242 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import logging
+import pytest
+
+from pathlib import Path
+
+from cm_client import (
+    ApiConfig,
+    ApiConfigList,
+    ApiRoleConfigGroup,
+)
+
+from ansible_collections.cloudera.cluster.plugins.modules import (
+    cm_service_role_config_group,
+)
+from ansible_collections.cloudera.cluster.tests.unit import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
+)
+def test_cm_role_config_group_config_set(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
+)
+def test_cm_role_config_group_config_unset(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
+)
+def test_cm_role_config_group_config_set_purge(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
+)
+def test_cm_role_config_group_config_purge_all(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict()
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(ApiRoleConfigGroup(display_name="Test"))
+def test_cm_role_config_group_display_name_set(
+    conn, module_args, host_monitor_config, request
+):
+    expected = "Updated Test"
+
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "display_name": expected,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected == e.value.role_config_group["display_name"]
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected == e.value.role_config_group["display_name"]

--- a/tests/unit/plugins/modules/cm_service_role_config_group/test_cm_service_role_config_group.py
+++ b/tests/unit/plugins/modules/cm_service_role_config_group/test_cm_service_role_config_group.py
@@ -54,12 +54,12 @@ LOG = logging.getLogger(__name__)
     )
 )
 def test_cm_role_config_group_config_set(
-    conn, module_args, host_monitor_config, request
+    conn, module_args, host_monitor_role_group_config, request
 ):
     module_args(
         {
             **conn,
-            "type": host_monitor_config.role_type,
+            "type": host_monitor_role_group_config.role_type,
             "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -96,12 +96,12 @@ def test_cm_role_config_group_config_set(
     )
 )
 def test_cm_role_config_group_config_unset(
-    conn, module_args, host_monitor_config, request
+    conn, module_args, host_monitor_role_group_config, request
 ):
     module_args(
         {
             **conn,
-            "type": host_monitor_config.role_type,
+            "type": host_monitor_role_group_config.role_type,
             "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -138,12 +138,12 @@ def test_cm_role_config_group_config_unset(
     )
 )
 def test_cm_role_config_group_config_set_purge(
-    conn, module_args, host_monitor_config, request
+    conn, module_args, host_monitor_role_group_config, request
 ):
     module_args(
         {
             **conn,
-            "type": host_monitor_config.role_type,
+            "type": host_monitor_role_group_config.role_type,
             "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
@@ -181,12 +181,12 @@ def test_cm_role_config_group_config_set_purge(
     )
 )
 def test_cm_role_config_group_config_purge_all(
-    conn, module_args, host_monitor_config, request
+    conn, module_args, host_monitor_role_group_config, request
 ):
     module_args(
         {
             **conn,
-            "type": host_monitor_config.role_type,
+            "type": host_monitor_role_group_config.role_type,
             "parameters": dict(),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
@@ -213,14 +213,14 @@ def test_cm_role_config_group_config_purge_all(
 
 @pytest.mark.role_config_group(ApiRoleConfigGroup(display_name="Test"))
 def test_cm_role_config_group_display_name_set(
-    conn, module_args, host_monitor_config, request
+    conn, module_args, host_monitor_role_group_config, request
 ):
     expected = "Updated Test"
 
     module_args(
         {
             **conn,
-            "type": host_monitor_config.role_type,
+            "type": host_monitor_role_group_config.role_type,
             "display_name": expected,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,

--- a/tests/unit/plugins/modules/cm_service_role_config_group_config/test_cm_service_role_config_group_config.py
+++ b/tests/unit/plugins/modules/cm_service_role_config_group_config/test_cm_service_role_config_group_config.py
@@ -60,11 +60,11 @@ def test_missing_required_if(conn, module_args):
         cm_service_role_config_group_config.main()
 
 
-def test_present_invalid_parameter(conn, module_args, host_monitor):
+def test_present_invalid_parameter(conn, module_args, host_monitor_role):
     module_args(
         {
             **conn,
-            "name": host_monitor.role_config_group_ref.role_config_group_name,
+            "name": host_monitor_role.role_config_group_ref.role_config_group_name,
             "parameters": dict(example="Example"),
         }
     )

--- a/tests/unit/plugins/modules/cm_service_role_config_group_config/test_cm_service_role_config_group_config.py
+++ b/tests/unit/plugins/modules/cm_service_role_config_group_config/test_cm_service_role_config_group_config.py
@@ -1,0 +1,379 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import logging
+import pytest
+
+from collections.abc import Generator
+from pathlib import Path
+
+from cm_client import (
+    ApiRole,
+    ApiRoleConfigGroup,
+    ClustersResourceApi,
+    MgmtRolesResourceApi,
+    MgmtRoleConfigGroupsResourceApi,
+)
+
+from ansible_collections.cloudera.cluster.plugins.modules import (
+    cm_service_role_config_group_config,
+)
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
+    get_mgmt_base_role_config_group,
+)
+
+from ansible_collections.cloudera.cluster.tests.unit import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    provision_cm_role,
+    set_cm_role_config_group_config,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def host_monitor(cm_api_client, cms, request) -> Generator[ApiRole]:
+    api = MgmtRolesResourceApi(cm_api_client)
+
+    hm = next(
+        iter([r for r in api.read_roles().items if r.type == "HOSTMONITOR"]), None
+    )
+
+    if hm is not None:
+        yield hm
+    else:
+        cluster_api = ClustersResourceApi(cm_api_client)
+
+        # Get first host of the cluster
+        hosts = cluster_api.list_hosts(cluster_name=cms.cluster_ref.cluster_name)
+
+        if not hosts.items:
+            raise Exception(
+                "No available hosts to assign the Cloudera Manager Service role."
+            )
+        else:
+            name = Path(request.fixturename).stem
+            yield from provision_cm_role(
+                cm_api_client, name, "HOSTMONITOR", hosts.items[0].hostId
+            )
+
+
+@pytest.fixture(scope="function")
+def host_monitor_config(
+    cm_api_client, host_monitor, request
+) -> Generator[ApiRoleConfigGroup]:
+    marker = request.node.get_closest_marker("role_config_group_config")
+
+    if marker is None:
+        raise Exception("No role_config_group_config marker found.")
+
+    rcg_api = MgmtRoleConfigGroupsResourceApi(cm_api_client)
+
+    yield from set_cm_role_config_group_config(
+        api_client=cm_api_client,
+        role_config_group=rcg_api.read_role_config_group(
+            host_monitor.role_config_group_ref.role_config_group_name
+        ),
+        params=marker.args[0],
+        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
+    )
+
+
+def test_missing_required(conn, module_args):
+    module_args(conn)
+
+    with pytest.raises(AnsibleFailJson, match="parameters"):
+        cm_service_role_config_group_config.main()
+
+
+def test_missing_required_if(conn, module_args):
+    module_args(
+        {
+            **conn,
+            "parameters": dict(),
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="name, type"):
+        cm_service_role_config_group_config.main()
+
+
+def test_present_invalid_parameter(conn, module_args, host_monitor):
+    module_args(
+        {
+            **conn,
+            "name": host_monitor.role_config_group_ref.role_config_group_name,
+            "parameters": dict(example="Example"),
+        }
+    )
+
+    with pytest.raises(
+        AnsibleFailJson, match="Unknown configuration attribute 'example'"
+    ):
+        cm_service_role_config_group_config.main()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "name": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_role_type(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32", process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_unset_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "name": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_unset_parameters_role_type(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+        }
+    )
+
+    expected = dict(process_start_secs="21")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_with_purge(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "name": host_monitor_config.name,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_set_parameters_with_purge_role_type(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(mgmt_num_descriptor_fetch_tries=32),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(mgmt_num_descriptor_fetch_tries="32")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
+    module_args(
+        {
+            **conn,
+            "name": host_monitor_config.name,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert len(e.value.config) == 0
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert len(e.value.config) == 0
+
+
+@pytest.mark.role_config_group_config(
+    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+)
+def test_purge_all_parameters_role_type(
+    conn, module_args, host_monitor_config, request
+):
+    module_args(
+        {
+            **conn,
+            "type": host_monitor_config.role_type,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == True
+    assert len(e.value.config) == 0
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        cm_service_role_config_group_config.main()
+
+    assert e.value.changed == False
+    assert len(e.value.config) == 0

--- a/tests/unit/plugins/modules/cm_service_role_config_group_config/test_cm_service_role_config_group_config.py
+++ b/tests/unit/plugins/modules/cm_service_role_config_group_config/test_cm_service_role_config_group_config.py
@@ -21,80 +21,24 @@ __metaclass__ = type
 import logging
 import pytest
 
-from collections.abc import Generator
 from pathlib import Path
 
 from cm_client import (
-    ApiRole,
+    ApiConfig,
+    ApiConfigList,
     ApiRoleConfigGroup,
-    ClustersResourceApi,
-    MgmtRolesResourceApi,
-    MgmtRoleConfigGroupsResourceApi,
 )
 
 from ansible_collections.cloudera.cluster.plugins.modules import (
     cm_service_role_config_group_config,
 )
-from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
-    get_mgmt_base_role_config_group,
-)
 
 from ansible_collections.cloudera.cluster.tests.unit import (
     AnsibleExitJson,
     AnsibleFailJson,
-    provision_cm_role,
-    set_cm_role_config_group_config,
 )
 
 LOG = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="module")
-def host_monitor(cm_api_client, cms, request) -> Generator[ApiRole]:
-    api = MgmtRolesResourceApi(cm_api_client)
-
-    hm = next(
-        iter([r for r in api.read_roles().items if r.type == "HOSTMONITOR"]), None
-    )
-
-    if hm is not None:
-        yield hm
-    else:
-        cluster_api = ClustersResourceApi(cm_api_client)
-
-        # Get first host of the cluster
-        hosts = cluster_api.list_hosts(cluster_name=cms.cluster_ref.cluster_name)
-
-        if not hosts.items:
-            raise Exception(
-                "No available hosts to assign the Cloudera Manager Service role."
-            )
-        else:
-            name = Path(request.fixturename).stem
-            yield from provision_cm_role(
-                cm_api_client, name, "HOSTMONITOR", hosts.items[0].hostId
-            )
-
-
-@pytest.fixture(scope="function")
-def host_monitor_config(
-    cm_api_client, host_monitor, request
-) -> Generator[ApiRoleConfigGroup]:
-    marker = request.node.get_closest_marker("role_config_group_config")
-
-    if marker is None:
-        raise Exception("No role_config_group_config marker found.")
-
-    rcg_api = MgmtRoleConfigGroupsResourceApi(cm_api_client)
-
-    yield from set_cm_role_config_group_config(
-        api_client=cm_api_client,
-        role_config_group=rcg_api.read_role_config_group(
-            host_monitor.role_config_group_ref.role_config_group_name
-        ),
-        params=marker.args[0],
-        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
-    )
 
 
 def test_missing_required(conn, module_args):
@@ -131,8 +75,17 @@ def test_present_invalid_parameter(conn, module_args, host_monitor):
         cm_service_role_config_group_config.main()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_set_parameters(conn, module_args, host_monitor_config, request):
     module_args(
@@ -162,8 +115,17 @@ def test_set_parameters(conn, module_args, host_monitor_config, request):
     assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_set_parameters_role_type(conn, module_args, host_monitor_config, request):
     module_args(
@@ -193,8 +155,17 @@ def test_set_parameters_role_type(conn, module_args, host_monitor_config, reques
     assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_unset_parameters(conn, module_args, host_monitor_config, request):
     module_args(
@@ -222,8 +193,17 @@ def test_unset_parameters(conn, module_args, host_monitor_config, request):
     assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_unset_parameters_role_type(conn, module_args, host_monitor_config, request):
     module_args(
@@ -251,8 +231,17 @@ def test_unset_parameters_role_type(conn, module_args, host_monitor_config, requ
     assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_set_parameters_with_purge(conn, module_args, host_monitor_config, request):
     module_args(
@@ -283,8 +272,17 @@ def test_set_parameters_with_purge(conn, module_args, host_monitor_config, reque
     assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_set_parameters_with_purge_role_type(
     conn, module_args, host_monitor_config, request
@@ -317,8 +315,17 @@ def test_set_parameters_with_purge_role_type(
     assert expected.items() <= {c["name"]: c["value"] for c in e.value.config}.items()
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
     module_args(
@@ -347,8 +354,17 @@ def test_purge_all_parameters(conn, module_args, host_monitor_config, request):
     assert len(e.value.config) == 0
 
 
-@pytest.mark.role_config_group_config(
-    dict(mgmt_num_descriptor_fetch_tries=11, process_start_secs=21)
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(
+                    mgmt_num_descriptor_fetch_tries=11, process_start_secs=21
+                ).items()
+            ]
+        )
+    )
 )
 def test_purge_all_parameters_role_type(
     conn, module_args, host_monitor_config, request

--- a/tests/unit/plugins/modules/service_config/test_service_config.py
+++ b/tests/unit/plugins/modules/service_config/test_service_config.py
@@ -128,11 +128,11 @@ def test_present_invalid_cluster(conn, module_args):
         service_config.main()
 
 
-def test_present_invalid_service(conn, module_args, target_service):
+def test_present_invalid_service(conn, module_args, zk_service):
     module_args(
         {
             **conn,
-            "cluster": target_service.cluster_ref.cluster_name,
+            "cluster": zk_service.cluster_ref.cluster_name,
             "service": "example",
             "parameters": dict(example="Example"),
         }
@@ -142,12 +142,12 @@ def test_present_invalid_service(conn, module_args, target_service):
         service_config.main()
 
 
-def test_present_invalid_parameter(conn, module_args, target_service):
+def test_present_invalid_parameter(conn, module_args, zk_service):
     module_args(
         {
             **conn,
-            "cluster": target_service.cluster_ref.cluster_name,
-            "service": target_service.name,
+            "cluster": zk_service.cluster_ref.cluster_name,
+            "service": zk_service.name,
             "parameters": dict(example="Example"),
         }
     )

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -12,4 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cm-client
+pre-commit
+pytest
+pytest-mock
+ansible-core<2.17 # For RHEL 8 support
+molecule
+molecule-plugins
+molecule-plugins[ec2]
+tox-ansible


### PR DESCRIPTION
Handles role override configurations, state, and host relocation.

Requires #258, #259, #260, and #261 -- will rebase after these are committed or resolved.

