### PR TITLE
Update service_role_config_group to align with CM modules

### DIFF
--- a/plugins/modules/cm_service_role_config_group.py
+++ b/plugins/modules/cm_service_role_config_group.py
@@ -45,7 +45,7 @@ options:
     description:
       - Whether to reset configuration parameters to only the declared entries.
     type: bool
-    default: no
+    default: False
 extends_documentation_fragment:
   - cloudera.cluster.cm_options
   - cloudera.cluster.cm_endpoint
@@ -61,6 +61,8 @@ requirements:
   - cm-client
 seealso:
   - module: cloudera.cluster.cm_service
+  - module: cloudera.cluster.cm_service_role
+  - module: cloudera.cluster.cm_service_role_config_group_info
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/service_role_config_group_info.py
+++ b/plugins/modules/service_role_config_group_info.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright 2025 Cloudera, Inc. All Rights Reserved.
@@ -46,8 +47,18 @@ options:
     aliases:
       - role_type
   name:
+  type:
+    description:
+      - The role type defining the role config group(s).
+      - If specified, will return all role config groups for the type.
+      - Mutually exclusive with O(name).
+    type: str
+    aliases:
+      - role_type
+  name:
     description:
       - The role config group to examine.
+      - If defined, the module will return the role config group.
       - If defined, the module will return the role config group.
       - If the role config group does not exist, the module will return an empty result.
     type: str
@@ -56,6 +67,13 @@ options:
 extends_documentation_fragment:
   - cloudera.cluster.cm_options
   - cloudera.cluster.cm_endpoint
+attributes:
+  check_mode:
+    support: full
+requirements:
+  - cm-client
+seealso:
+  - module: cloudera.cluster.service_role_config_group
 attributes:
   check_mode:
     support: full
@@ -90,23 +108,28 @@ RETURN = r"""
 role_config_groups:
   description:
     - List of cluster service role config groups.
+    - List of cluster service role config groups.
   type: list
   elements: dict
   returned: always
   contains:
     name:
       description: Name (identifier) of the role config group.
+      description: Name (identifier) of the role config group.
       type: str
       returned: always
     role_type:
+      description: The type of the roles in this role config group.
       description: The type of the roles in this role config group.
       type: str
       returned: always
     base:
       description: Flag indicating whether this is a base role config group.
+      description: Flag indicating whether this is a base role config group.
       type: bool
       returned: always
     display_name:
+      description: A user-friendly name of the role config group, as would have been shown in the web UI.
       description: A user-friendly name of the role config group, as would have been shown in the web UI.
       type: str
       returned: when supported

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -922,10 +922,12 @@ def host_monitor_state(
 
 
 @pytest.fixture(scope="function")
-def zk_base_role_config_group(
+def zk_role_config_group(
     cm_api_client, zk_session, request
 ) -> Generator[ApiRoleConfigGroup]:
-    """Configures the base Role Config Group for the SERVER role of a ZooKeeper service."""
+    """
+    Creates or updates a Role Config Group of a ZooKeeper service, i.e. a SERVER role type group.
+    """
     marker = request.node.get_closest_marker("role_config_group")
 
     if marker is None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,6 +41,7 @@ from cm_client import (
     ApiHostRefList,
     ApiRole,
     ApiRoleConfigGroup,
+    ApiRoleConfigGroupList,
     ApiRoleList,
     ApiRoleNameList,
     ApiRoleState,
@@ -59,6 +60,7 @@ from cm_client import (
     ParcelResourceApi,
     ParcelsResourceApi,
     ServicesResourceApi,
+    RoleConfigGroupsResourceApi,
 )
 from cm_client.rest import ApiException, RESTClientObject
 
@@ -67,6 +69,10 @@ from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.parcel_utils import (
     Parcel,
+)
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
+    get_base_role_config_group,
 )
 
 from ansible_collections.cloudera.cluster.plugins.module_utils.role_utils import (
@@ -79,6 +85,7 @@ from ansible_collections.cloudera.cluster.tests.unit import (
     provision_cm_role,
     set_cm_role_config,
     set_cm_role_config_group,
+    set_role_config_group,
 )
 
 
@@ -87,6 +94,10 @@ class NoHostsFoundException(Exception):
 
 
 class ParcelNotFoundException(Exception):
+    pass
+
+
+class ZooKeeperServiceNotFoundException(Exception):
     pass
 
 
@@ -377,7 +388,7 @@ def base_cluster(cm_api_client, cms_session) -> Generator[ApiCluster]:
 
 
 @pytest.fixture(scope="function")
-def zk_auto(cm_api_client, base_cluster, request) -> Generator[ApiService]:
+def zk_function(cm_api_client, base_cluster, request) -> Generator[ApiService]:
     """Create a new ZooKeeper service on the provided base cluster.
     It starts this service, yields, and will remove this service if the tests
     do not.
@@ -405,6 +416,66 @@ def zk_auto(cm_api_client, base_cluster, request) -> Generator[ApiService]:
 
     payload = ApiService(
         name="-".join(["zk", request.node.name]),
+        type="ZOOKEEPER",
+        roles=[
+            ApiRole(
+                type="SERVER",
+                host_ref=ApiHostRef(host.host_id, host.hostname),
+            ),
+        ],
+    )
+
+    service_results = service_api.create_services(
+        cluster_name=base_cluster.name, body=ApiServiceList(items=[payload])
+    )
+
+    first_run_cmd = service_api.first_run(
+        cluster_name=base_cluster.name,
+        service_name=service_results.items[0].name,
+    )
+
+    monitor_command(cm_api_client, first_run_cmd)
+
+    zk_service = service_api.read_service(
+        cluster_name=base_cluster.name, service_name=service_results.items[0].name
+    )
+
+    yield zk_service
+
+    service_api.delete_service(
+        cluster_name=base_cluster.name,
+        service_name=zk_service.name,
+    )
+
+
+@pytest.fixture(scope="session")
+def zk_session(cm_api_client, base_cluster) -> Generator[ApiService]:
+    """Create a new ZooKeeper service on the provided base cluster.
+    It starts this service, yields, and will remove this service if the tests
+    do not.
+
+    Args:
+        cm_api_client (ApiClient): CM API client
+        base_cluster (ApiCluster): Provided base cluster
+
+    Yields:
+        Generator[ApiService]: ZooKeeper service
+    """
+
+    service_api = ServicesResourceApi(cm_api_client)
+    cm_api = ClustersResourceApi(cm_api_client)
+
+    host = next(
+        (h for h in cm_api.list_hosts(cluster_name=base_cluster.name).items), None
+    )
+
+    if host is None:
+        raise NoHostsFoundException(
+            "No available hosts to assign ZooKeeper service roles"
+        )
+
+    payload = ApiService(
+        name="zk-session",
         type="ZOOKEEPER",
         roles=[
             ApiRole(
@@ -848,6 +919,78 @@ def host_monitor_state(
                     body=ApiRoleNameList(items=[host_monitor.name])
                 ),
             )
+
+
+@pytest.fixture(scope="function")
+def zk_base_role_config_group(
+    cm_api_client, zk_session, request
+) -> Generator[ApiRoleConfigGroup]:
+    """Configures the base Role Config Group for the SERVER role of a ZooKeeper service."""
+    marker = request.node.get_closest_marker("role_config_group")
+
+    if marker is None:
+        raise Exception("No 'role_config_group' marker found.")
+
+    update_rcg = marker.args[0]
+
+    rcg_api = RoleConfigGroupsResourceApi(cm_api_client)
+
+    rcg = None
+    if update_rcg.name is not None:
+        # If it exists, update it
+        try:
+            rcg = rcg_api.read_role_config_group(
+                cluster_name=zk_session.cluster_ref.cluster_name,
+                service_name=zk_session.name,
+                role_config_group_name=update_rcg.name,
+            )
+        except ApiException as ex:
+            if ex.status != 404:
+                raise ex
+
+        # If it doesn't exist, create, yield, and destroy
+        if rcg is None:
+            rcg = rcg_api.create_role_config_groups(
+                cluster_name=zk_session.cluster_ref.cluster_name,
+                service_name=zk_session.name,
+                body=ApiRoleConfigGroupList(items=[update_rcg]),
+            ).items[0]
+
+            yield rcg
+
+            try:
+                rcg_api.delete_role_config_group(
+                    cluster_name=zk_session.cluster_ref.cluster_name,
+                    service_name=zk_session.name,
+                    role_config_group_name=rcg.name,
+                )
+            except ApiException as ex:
+                if ex.status != 404:
+                    raise ex
+
+            return
+    else:
+        rcg = get_base_role_config_group(
+            api_client=cm_api_client,
+            cluster_name=zk_session.cluster_ref.cluster_name,
+            service_name=zk_session.name,
+            role_type="SERVER",
+        )
+
+    rcg.config = rcg_api.read_config(
+        cluster_name=zk_session.cluster_ref.cluster_name,
+        service_name=zk_session.name,
+        role_config_group_name=rcg.name,
+    )
+
+    yield from set_role_config_group(
+        api_client=cm_api_client,
+        cluster_name=zk_session.cluster_ref.cluster_name,
+        service_name=zk_session.name,
+        role_config_group=rcg,
+        update=update_rcg,
+        message=f"{Path(request.node.parent.name).stem}::{request.node.name}",
+    )
 
 
 def handle_commands(api_client: ApiClient, commands: ApiBulkCommandList):

--- a/tests/unit/plugins/modules/cm_service_role_config_group/test_cm_service_role_config_group.py
+++ b/tests/unit/plugins/modules/cm_service_role_config_group/test_cm_service_role_config_group.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+# Copyright 2025 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/plugins/modules/service_role_config_group/test_service_role_config_group.py
+++ b/tests/unit/plugins/modules/service_role_config_group/test_service_role_config_group.py
@@ -28,6 +28,8 @@ from cm_client import (
     ApiConfig,
     ApiConfigList,
     ApiRoleConfigGroup,
+    ApiRoleNameList,
+    RoleConfigGroupsResourceApi,
 )
 
 from ansible_collections.cloudera.cluster.plugins.modules import (
@@ -46,7 +48,7 @@ from ansible_collections.cloudera.cluster.tests.unit import (
 LOG = logging.getLogger(__name__)
 
 
-def test_role_config_group_missing_required(conn, module_args):
+def test_missing_required(conn, module_args):
     module_args(
         {
             **conn,
@@ -61,6 +63,34 @@ def test_role_config_group_missing_required(conn, module_args):
         service_role_config_group.main()
 
 
+def test_invalid_service(conn, module_args, base_cluster):
+    module_args(
+        {
+            **conn,
+            "cluster": base_cluster.name,
+            "service": "BOOM",
+            "type": "BOOM",
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="Service does not exist: BOOM"):
+        service_role_config_group.main()
+
+
+def test_invalid_cluster(conn, module_args, cms_session):
+    module_args(
+        {
+            **conn,
+            "cluster": "BOOM",
+            "service": "BOOM",
+            "type": "BOOM",
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="Cluster does not exist: BOOM"):
+        service_role_config_group.main()
+
+
 @pytest.mark.role_config_group(
     ApiRoleConfigGroup(
         config=ApiConfigList(
@@ -71,15 +101,13 @@ def test_role_config_group_missing_required(conn, module_args):
         )
     )
 )
-def test_base_role_config_group_set(
-    conn, module_args, zk_base_role_config_group, request
-):
+def test_base_role_config_group_set(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "type": zk_base_role_config_group.role_type,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "type": zk_role_config_group.role_type,
             "parameters": dict(minSessionTimeout=3000),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -113,15 +141,13 @@ def test_base_role_config_group_set(
         )
     )
 )
-def test_base_role_config_group_unset(
-    conn, module_args, zk_base_role_config_group, request
-):
+def test_base_role_config_group_unset(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "type": zk_base_role_config_group.role_type,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "type": zk_role_config_group.role_type,
             "parameters": dict(minSessionTimeout=None),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -155,15 +181,13 @@ def test_base_role_config_group_unset(
         )
     )
 )
-def test_base_role_config_group_purge(
-    conn, module_args, zk_base_role_config_group, request
-):
+def test_base_role_config_group_purge(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "type": zk_base_role_config_group.role_type,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "type": zk_role_config_group.role_type,
             "parameters": dict(minSessionTimeout=2701),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
@@ -199,14 +223,14 @@ def test_base_role_config_group_purge(
     )
 )
 def test_base_role_config_group_purge_all(
-    conn, module_args, zk_base_role_config_group, request
+    conn, module_args, zk_role_config_group, request
 ):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "type": zk_base_role_config_group.role_type,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "type": zk_role_config_group.role_type,
             "parameters": dict(),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
@@ -304,13 +328,13 @@ def test_role_config_group_create(conn, module_args, zk_session, request):
         ),
     )
 )
-def test_role_config_group_set(conn, module_args, zk_base_role_config_group, request):
+def test_role_config_group_set(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "name": zk_base_role_config_group.name,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": zk_role_config_group.name,
             "parameters": dict(minSessionTimeout=3000),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -346,13 +370,13 @@ def test_role_config_group_set(conn, module_args, zk_base_role_config_group, req
         ),
     )
 )
-def test_role_config_group_unset(conn, module_args, zk_base_role_config_group, request):
+def test_role_config_group_unset(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "name": zk_base_role_config_group.name,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": zk_role_config_group.name,
             "parameters": dict(minSessionTimeout=None),
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -388,13 +412,13 @@ def test_role_config_group_unset(conn, module_args, zk_base_role_config_group, r
         ),
     )
 )
-def test_role_config_group_purge(conn, module_args, zk_base_role_config_group, request):
+def test_role_config_group_purge(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "name": zk_base_role_config_group.name,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": zk_role_config_group.name,
             "parameters": dict(minSessionTimeout=3000),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
@@ -431,15 +455,13 @@ def test_role_config_group_purge(conn, module_args, zk_base_role_config_group, r
         ),
     )
 )
-def test_role_config_group_purge_all(
-    conn, module_args, zk_base_role_config_group, request
-):
+def test_role_config_group_purge_all(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "name": zk_base_role_config_group.name,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": zk_role_config_group.name,
             "parameters": dict(),
             "purge": True,
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
@@ -476,15 +498,13 @@ def test_role_config_group_purge_all(
         ),
     )
 )
-def test_role_config_group_absent(
-    conn, module_args, zk_base_role_config_group, request
-):
+def test_role_config_group_absent(conn, module_args, zk_role_config_group, request):
     module_args(
         {
             **conn,
-            "cluster": zk_base_role_config_group.service_ref.cluster_name,
-            "service": zk_base_role_config_group.service_ref.service_name,
-            "name": zk_base_role_config_group.name,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": zk_role_config_group.name,
             "state": "absent",
             "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
             # _ansible_check_mode=True,
@@ -504,3 +524,111 @@ def test_role_config_group_absent(
 
     assert e.value.changed == False
     assert not e.value.role_config_group
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Invalid Type",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_role_config_group_invalid_type(
+    conn, module_args, zk_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": "Pytest Invalid Type",
+            "type": "INVALID",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="Invalid role type") as e:
+        service_role_config_group.main()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Invalid Configuration",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_role_config_group_invalid_config(
+    conn, module_args, zk_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": "Pytest Invalid Configuration",
+            "config": dict(invalid_configuration_parameter="BOOM"),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="Unknown configuration attribute") as e:
+        service_role_config_group.main()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Absent",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_role_config_group_existing_roles(
+    conn, module_args, cm_api_client, zk_role_config_group, request
+):
+    base_rcg = get_base_role_config_group(
+        api_client=cm_api_client,
+        cluster_name=zk_role_config_group.service_ref.cluster_name,
+        service_name=zk_role_config_group.service_ref.service_name,
+        role_type="SERVER",
+    )
+
+    rcg_api = RoleConfigGroupsResourceApi(cm_api_client)
+    role_list = rcg_api.read_roles(
+        cluster_name=zk_role_config_group.service_ref.cluster_name,
+        service_name=zk_role_config_group.service_ref.service_name,
+        role_config_group_name=base_rcg.name,
+    )
+
+    rcg_api.move_roles(
+        cluster_name=zk_role_config_group.service_ref.cluster_name,
+        service_name=zk_role_config_group.service_ref.service_name,
+        role_config_group_name="Pytest Absent",
+        body=ApiRoleNameList(items=[role_list.items[0].name]),
+    )
+
+    module_args(
+        {
+            **conn,
+            "cluster": zk_role_config_group.service_ref.cluster_name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": "Pytest Absent",
+            "state": "absent",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="existing role associations") as e:
+        service_role_config_group.main()
+
+    rcg_api.move_roles_to_base_group(
+        cluster_name=zk_role_config_group.service_ref.cluster_name,
+        service_name=zk_role_config_group.service_ref.service_name,
+        body=ApiRoleNameList(items=[role_list.items[0].name]),
+    )

--- a/tests/unit/plugins/modules/service_role_config_group/test_service_role_config_group.py
+++ b/tests/unit/plugins/modules/service_role_config_group/test_service_role_config_group.py
@@ -1,0 +1,506 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2025 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import logging
+import pytest
+
+from pathlib import Path
+
+from cm_client import (
+    ApiConfig,
+    ApiConfigList,
+    ApiRoleConfigGroup,
+)
+
+from ansible_collections.cloudera.cluster.plugins.modules import (
+    service_role_config_group,
+)
+
+from ansible_collections.cloudera.cluster.plugins.module_utils.role_config_group_utils import (
+    get_base_role_config_group,
+)
+
+from ansible_collections.cloudera.cluster.tests.unit import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+def test_role_config_group_missing_required(conn, module_args):
+    module_args(
+        {
+            **conn,
+            "cluster": "CLUSTER",
+            "service": "SERVICE",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleFailJson, match="name, role_type"):
+        service_role_config_group.main()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=2500, process_start_secs=25).items()
+            ]
+        )
+    )
+)
+def test_base_role_config_group_set(
+    conn, module_args, zk_base_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "type": zk_base_role_config_group.role_type,
+            "parameters": dict(minSessionTimeout=3000),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(minSessionTimeout="3000", process_start_secs="25")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=2600, process_start_secs=26).items()
+            ]
+        )
+    )
+)
+def test_base_role_config_group_unset(
+    conn, module_args, zk_base_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "type": zk_base_role_config_group.role_type,
+            "parameters": dict(minSessionTimeout=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(process_start_secs="26")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=2700, process_start_secs=27).items()
+            ]
+        )
+    )
+)
+def test_base_role_config_group_purge(
+    conn, module_args, zk_base_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "type": zk_base_role_config_group.role_type,
+            "parameters": dict(minSessionTimeout=2701),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(minSessionTimeout="2701")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=2800, process_start_secs=28).items()
+            ]
+        )
+    )
+)
+def test_base_role_config_group_purge_all(
+    conn, module_args, zk_base_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "type": zk_base_role_config_group.role_type,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict()
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+def test_base_role_config_group_absent(
+    conn, module_args, cm_api_client, zk_session, request
+):
+    rcg = get_base_role_config_group(
+        api_client=cm_api_client,
+        cluster_name=zk_session.cluster_ref.cluster_name,
+        service_name=zk_session.name,
+        role_type="SERVER",
+    )
+
+    module_args(
+        {
+            **conn,
+            "cluster": rcg.service_ref.cluster_name,
+            "service": rcg.service_ref.service_name,
+            "type": rcg.role_type,
+            "state": "absent",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(
+        AnsibleFailJson,
+        match="Deletion failed\. Role config group is a base \(default\) group\.",
+    ) as e:
+        service_role_config_group.main()
+
+
+def test_role_config_group_create(conn, module_args, zk_session, request):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_session.cluster_ref.cluster_name,
+            "service": zk_session.name,
+            "type": "SERVER",
+            "name": f"pyest-{zk_session.name}",
+            "parameters": dict(minSessionTimeout=3000),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(minSessionTimeout="3000")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Set",
+        role_type="SERVER",
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=2800, process_start_secs=28).items()
+            ]
+        ),
+    )
+)
+def test_role_config_group_set(conn, module_args, zk_base_role_config_group, request):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "name": zk_base_role_config_group.name,
+            "parameters": dict(minSessionTimeout=3000),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(minSessionTimeout="3000", process_start_secs="28")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Set",
+        role_type="SERVER",
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=2900, process_start_secs=29).items()
+            ]
+        ),
+    )
+)
+def test_role_config_group_unset(conn, module_args, zk_base_role_config_group, request):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "name": zk_base_role_config_group.name,
+            "parameters": dict(minSessionTimeout=None),
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(process_start_secs="29")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Set",
+        role_type="SERVER",
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=3100, process_start_secs=31).items()
+            ]
+        ),
+    )
+)
+def test_role_config_group_purge(conn, module_args, zk_base_role_config_group, request):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "name": zk_base_role_config_group.name,
+            "parameters": dict(minSessionTimeout=3000),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict(minSessionTimeout="3000")
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Set",
+        role_type="SERVER",
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=3200, process_start_secs=32).items()
+            ]
+        ),
+    )
+)
+def test_role_config_group_purge_all(
+    conn, module_args, zk_base_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "name": zk_base_role_config_group.name,
+            "parameters": dict(),
+            "purge": True,
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    expected = dict()
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert expected.items() <= e.value.role_config_group["config"].items()
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Set",
+        role_type="SERVER",
+        config=ApiConfigList(
+            items=[
+                ApiConfig(k, v)
+                for k, v in dict(minSessionTimeout=3100, process_start_secs=31).items()
+            ]
+        ),
+    )
+)
+def test_role_config_group_absent(
+    conn, module_args, zk_base_role_config_group, request
+):
+    module_args(
+        {
+            **conn,
+            "cluster": zk_base_role_config_group.service_ref.cluster_name,
+            "service": zk_base_role_config_group.service_ref.service_name,
+            "name": zk_base_role_config_group.name,
+            "state": "absent",
+            "message": f"{Path(request.node.parent.name).stem}::{request.node.name}",
+            # _ansible_check_mode=True,
+            # _ansible_diff=True,
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == True
+    assert not e.value.role_config_group
+
+    # Idempotency
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group.main()
+
+    assert e.value.changed == False
+    assert not e.value.role_config_group

--- a/tests/unit/plugins/modules/service_role_config_group_info/test_service_role_config_group_info.py
+++ b/tests/unit/plugins/modules/service_role_config_group_info/test_service_role_config_group_info.py
@@ -63,7 +63,7 @@ def test_invalid_service(conn, module_args, base_cluster):
         service_role_config_group_info.main()
 
 
-def test_invalid_cluster(conn, module_args, base_cluster):
+def test_invalid_cluster(conn, module_args, cms_session):
     module_args(
         {
             **conn,
@@ -76,12 +76,12 @@ def test_invalid_cluster(conn, module_args, base_cluster):
         service_role_config_group_info.main()
 
 
-def test_all_role_config_groups(conn, module_args, base_cluster, zk_auto):
+def test_all_role_config_groups(conn, module_args, base_cluster, zk_session):
     module_args(
         {
             **conn,
             "cluster": base_cluster.name,
-            "service": zk_auto.name,
+            "service": zk_session.name,
         }
     )
 
@@ -93,12 +93,12 @@ def test_all_role_config_groups(conn, module_args, base_cluster, zk_auto):
     assert e.value.role_config_groups[0]["base"] == True
 
 
-def test_type_role_config_group(conn, module_args, base_cluster, zk_auto):
+def test_type_role_config_group(conn, module_args, base_cluster, zk_session):
     module_args(
         {
             **conn,
             "cluster": base_cluster.name,
-            "service": zk_auto.name,
+            "service": zk_session.name,
             "type": "SERVER",
         }
     )
@@ -112,12 +112,12 @@ def test_type_role_config_group(conn, module_args, base_cluster, zk_auto):
 
 
 def test_name_role_config_group(
-    conn, module_args, cm_api_client, base_cluster, zk_auto
+    conn, module_args, cm_api_client, base_cluster, zk_session
 ):
     base_rcg = get_base_role_config_group(
         api_client=cm_api_client,
         cluster_name=base_cluster.name,
-        service_name=zk_auto.name,
+        service_name=zk_session.name,
         role_type="SERVER",
     )
 
@@ -125,7 +125,7 @@ def test_name_role_config_group(
         {
             **conn,
             "cluster": base_cluster.name,
-            "service": zk_auto.name,
+            "service": zk_session.name,
             "name": base_rcg.name,
         }
     )

--- a/tests/unit/plugins/modules/service_role_config_group_info/test_service_role_config_group_info.py
+++ b/tests/unit/plugins/modules/service_role_config_group_info/test_service_role_config_group_info.py
@@ -21,6 +21,11 @@ __metaclass__ = type
 import logging
 import pytest
 
+from cm_client import (
+    ApiConfigList,
+    ApiRoleConfigGroup,
+)
+
 from ansible_collections.cloudera.cluster.plugins.modules import (
     service_role_config_group_info,
 )
@@ -43,10 +48,16 @@ def test_missing_required(conn, module_args):
 
 
 def test_missing_cluster(conn, module_args):
-    conn.update(service="example")
-    module_args(conn)
+    module_args({**conn, "service": "example"})
 
     with pytest.raises(AnsibleFailJson, match="cluster"):
+        service_role_config_group_info.main()
+
+
+def test_missing_service(conn, module_args, base_cluster):
+    module_args({**conn, "cluster": base_cluster.name})
+
+    with pytest.raises(AnsibleFailJson, match="service"):
         service_role_config_group_info.main()
 
 
@@ -76,29 +87,41 @@ def test_invalid_cluster(conn, module_args, cms_session):
         service_role_config_group_info.main()
 
 
-def test_all_role_config_groups(conn, module_args, base_cluster, zk_session):
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest All",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_all_role_config_groups(conn, module_args, base_cluster, zk_role_config_group):
     module_args(
         {
             **conn,
             "cluster": base_cluster.name,
-            "service": zk_session.name,
+            "service": zk_role_config_group.service_ref.service_name,
         }
     )
 
     with pytest.raises(AnsibleExitJson) as e:
         service_role_config_group_info.main()
 
-    # Should be only one BASE for the SERVER
-    assert len(e.value.role_config_groups) == 1
-    assert e.value.role_config_groups[0]["base"] == True
+    assert len(e.value.role_config_groups) == 2
 
 
-def test_type_role_config_group(conn, module_args, base_cluster, zk_session):
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Type",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_type_role_config_group(conn, module_args, base_cluster, zk_role_config_group):
     module_args(
         {
             **conn,
             "cluster": base_cluster.name,
-            "service": zk_session.name,
+            "service": zk_role_config_group.service_ref.service_name,
             "type": "SERVER",
         }
     )
@@ -106,18 +129,23 @@ def test_type_role_config_group(conn, module_args, base_cluster, zk_session):
     with pytest.raises(AnsibleExitJson) as e:
         service_role_config_group_info.main()
 
-    # Should be only one BASE for the SERVER
-    assert len(e.value.role_config_groups) == 1
-    assert e.value.role_config_groups[0]["base"] == True
+    assert len(e.value.role_config_groups) == 2
 
 
-def test_name_role_config_group(
-    conn, module_args, cm_api_client, base_cluster, zk_session
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Base",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_name_base_role_config_group(
+    conn, module_args, cm_api_client, base_cluster, zk_role_config_group
 ):
     base_rcg = get_base_role_config_group(
         api_client=cm_api_client,
         cluster_name=base_cluster.name,
-        service_name=zk_session.name,
+        service_name=zk_role_config_group.service_ref.service_name,
         role_type="SERVER",
     )
 
@@ -125,7 +153,7 @@ def test_name_role_config_group(
         {
             **conn,
             "cluster": base_cluster.name,
-            "service": zk_session.name,
+            "service": zk_role_config_group.name,
             "name": base_rcg.name,
         }
     )
@@ -136,3 +164,30 @@ def test_name_role_config_group(
     # Should be only one BASE for the SERVER
     assert len(e.value.role_config_groups) == 1
     assert e.value.role_config_groups[0]["base"] == True
+
+
+@pytest.mark.role_config_group(
+    ApiRoleConfigGroup(
+        name="Pytest Non-Base",
+        role_type="SERVER",
+        config=ApiConfigList(items=[]),
+    )
+)
+def test_name_base_role_config_group(
+    conn, module_args, base_cluster, zk_role_config_group
+):
+    module_args(
+        {
+            **conn,
+            "cluster": base_cluster.name,
+            "service": zk_role_config_group.service_ref.service_name,
+            "name": "Pytest Non-Base",
+        }
+    )
+
+    with pytest.raises(AnsibleExitJson) as e:
+        service_role_config_group_info.main()
+
+    # Should be only one non-BASE for the SERVER
+    assert len(e.value.role_config_groups) == 1
+    assert e.value.role_config_groups[0]["base"] == False


### PR DESCRIPTION
Notably, this module no longer handles the role _association_ with the role config group. That responsibility will be delegated to other modules addressing `service` and `role` (including `cluster`).  This role does _report_ on role associations.