### PR TITLE
Deprecate legacy roles

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -25,6 +25,7 @@ roles/cloudera_manager/autotls/tasks/patch_old_cm.yml command-instead-of-shell
 roles/cloudera_manager/autotls/tasks/patch_old_cm.yml fqcn[action-core]
 roles/cloudera_manager/autotls/tasks/patch_old_cm.yml jinja[spacing]
 roles/cloudera_manager/autotls/tasks/patch_old_cm.yml no-changed-when
+roles/cloudera_manager/common/defaults/main.yml var-naming[no-role-prefix]
 roles/cloudera_manager/common/handlers/main.yml fqcn[action-core]
 roles/cloudera_manager/common/handlers/main.yml name[casing]
 roles/cloudera_manager/config/defaults/main.yml var-naming[no-role-prefix]

--- a/plugins/modules/deprecation.py
+++ b/plugins/modules/deprecation.py
@@ -16,25 +16,35 @@
 # limitations under the License.
 
 DOCUMENTATION = r"""
-module: warn
-short_description: Display a warning
+module: deprecation
+short_description: Display a deprecation warning
 description:
-  - Displays a standard Ansible module warning.
+  - Displays a standard Ansible deprecation warning
 author:
   - "Webster Mudge (@wmudge)"
 version_added: "5.0.0"
 options:
   msg:
     description:
-      - The warning message.
+      - The deprecation warning message.
     type: str
     required: true
+  version:
+    description:
+      - Version details for the warning message.
+    type: str
+    required: false
 """
 
 EXAMPLES = r"""
-- name: Display a warning
-  cloudera.cluster.warn:
-    msg: This is a warning message.
+- name: Display a deprecation warning
+  cloudera.cluster.deprecation:
+    msg: A custom warning
+
+- name: Display the deprecation warning with version details
+  cloudera.cluster.deprecation:
+    msg: A custom warning with version info
+    version: "5.0.0"
 """
 
 RETURN = r""""""
@@ -46,8 +56,9 @@ if __name__ == "__main__":
     module = AnsibleModule(
         argument_spec=dict(
             msg=dict(required="True"),
+            version=dict(),
         ),
     )
 
-    module.warn(module.params["msg"])
+    module.deprecate(module.params.get("msg"), module.params.get("version", None))
     module.exit_json()

--- a/plugins/modules/warn.py
+++ b/plugins/modules/warn.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2025 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = r"""
+module: warn
+short_description: Display a warning
+description:
+  - Displays a standard Ansible module warning.
+author:
+  - "Webster Mudge (@wmudge)"
+version_added: "5.0.0"
+options:
+  msg:
+    description:
+      - The warning message.
+    type: str
+    required: true
+"""
+
+EXAMPLES = r"""
+- name: Display a warning
+  cloudera.cluster.warn:
+    msg: This is a warning message.
+"""
+
+RETURN = r""""""
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+if __name__ == "__main__":
+    module = AnsibleModule(
+        argument_spec=dict(
+            msg=dict(required="True"),
+        ),
+    )
+
+    module.warn(module.params["msg"])
+    module.exit_json()

--- a/roles/cloudera_manager/admin_password/check/tasks/main.yml
+++ b/roles/cloudera_manager/admin_password/check/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Wait for Cloudera Manager Port to be up
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"

--- a/roles/cloudera_manager/admin_password/check/tasks/main.yml
+++ b/roles/cloudera_manager/admin_password/check/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Wait for Cloudera Manager Port to be up
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   ansible.builtin.wait_for:

--- a/roles/cloudera_manager/admin_password/set/tasks/main.yml
+++ b/roles/cloudera_manager/admin_password/set/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Update the Cloudera Manager admin password
   cloudera.cluster.cm_api:

--- a/roles/cloudera_manager/admin_password/set/tasks/main.yml
+++ b/roles/cloudera_manager/admin_password/set/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Update the Cloudera Manager admin password
   cloudera.cluster.cm_api:
     endpoint: /users/admin

--- a/roles/cloudera_manager/agent/tasks/main.yml
+++ b/roles/cloudera_manager/agent/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Gather the package facts
   ansible.builtin.package_facts:

--- a/roles/cloudera_manager/agent/tasks/main.yml
+++ b/roles/cloudera_manager/agent/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/roles/cloudera_manager/agent_config/tasks/main.yml
+++ b/roles/cloudera_manager/agent_config/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Set Cloudera Manager agent 'server_host' in config.ini
   lineinfile:
     dest: "{{ cloudera_manager_agent_config_file }}"

--- a/roles/cloudera_manager/agent_config/tasks/main.yml
+++ b/roles/cloudera_manager/agent_config/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Set Cloudera Manager agent 'server_host' in config.ini
   lineinfile:

--- a/roles/cloudera_manager/api_client/tasks/main.yml
+++ b/roles/cloudera_manager/api_client/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - set_fact:
     cloudera_manager_url: "{{ cloudera_manager_protocol }}://{{ cloudera_manager_host }}:{{ cloudera_manager_port }}"

--- a/roles/cloudera_manager/api_client/tasks/main.yml
+++ b/roles/cloudera_manager/api_client/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - set_fact:
     cloudera_manager_url: "{{ cloudera_manager_protocol }}://{{ cloudera_manager_host }}:{{ cloudera_manager_port }}"
   when: cloudera_manager_url is not defined

--- a/roles/cloudera_manager/api_hosts/tasks/main.yml
+++ b/roles/cloudera_manager/api_hosts/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Get the host identifiers and names from Cloudera Manager
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"

--- a/roles/cloudera_manager/api_hosts/tasks/main.yml
+++ b/roles/cloudera_manager/api_hosts/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Get the host identifiers and names from Cloudera Manager
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   cloudera.cluster.cm_api:

--- a/roles/cloudera_manager/autotls/tasks/main.yml
+++ b/roles/cloudera_manager/autotls/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Check Cloudera Manager version
   cloudera.cluster.cm_api:

--- a/roles/cloudera_manager/autotls/tasks/main.yml
+++ b/roles/cloudera_manager/autotls/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Check Cloudera Manager version
   cloudera.cluster.cm_api:
     endpoint: /cm/version

--- a/roles/cloudera_manager/cms_tls/tasks/main.yml
+++ b/roles/cloudera_manager/cms_tls/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Setup TLS for Activity Monitor
   cm_api:
     method: PUT

--- a/roles/cloudera_manager/cms_tls/tasks/main.yml
+++ b/roles/cloudera_manager/cms_tls/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Setup TLS for Activity Monitor
   cm_api:

--- a/roles/cloudera_manager/common/defaults/main.yml
+++ b/roles/cloudera_manager/common/defaults/main.yml
@@ -30,9 +30,3 @@ cloudera_manager_database_password: changeme
 cloudera_manager_database_port: "{{ database_type | cloudera.cluster.default_database_port }}"
 cloudera_manager_agent_lib_directory: /var/lib/cloudera-scm-agent
 cloudera_manager_cmf_java_opts_default: "-Xmx4G -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
-
-deprecation_msg: |
-  This role will be removed from the collection in release 6.0.0.
-  Please refer to the collection README for details.
-  Deprecation warnings can be disabled by setting deprecation_warnings=False in
-  ansible.cfg.

--- a/roles/cloudera_manager/common/defaults/main.yml
+++ b/roles/cloudera_manager/common/defaults/main.yml
@@ -30,3 +30,9 @@ cloudera_manager_database_password: changeme
 cloudera_manager_database_port: "{{ database_type | cloudera.cluster.default_database_port }}"
 cloudera_manager_agent_lib_directory: /var/lib/cloudera-scm-agent
 cloudera_manager_cmf_java_opts_default: "-Xmx4G -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+
+deprecation_msg: |
+  This role will be removed from the collection in release 6.0.0.
+  Please refer to the collection README for details.
+  Deprecation warnings can be disabled by setting deprecation_warnings=False in
+  ansible.cfg.

--- a/roles/cloudera_manager/config/tasks/main.yml
+++ b/roles/cloudera_manager/config/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Get existing configs
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   cloudera.cluster.cm_api:

--- a/roles/cloudera_manager/config/tasks/main.yml
+++ b/roles/cloudera_manager/config/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Get existing configs
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"

--- a/roles/cloudera_manager/csds/tasks/main.yml
+++ b/roles/cloudera_manager/csds/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Create CSD directory
   file:
     path: "{{ cloudera_manager_csd_directory }}"

--- a/roles/cloudera_manager/csds/tasks/main.yml
+++ b/roles/cloudera_manager/csds/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Create CSD directory
   file:

--- a/roles/cloudera_manager/daemons/tasks/main.yml
+++ b/roles/cloudera_manager/daemons/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Install Cloudera Manager daemons package
   ansible.builtin.package:
     lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(180, omit) }}"

--- a/roles/cloudera_manager/daemons/tasks/main.yml
+++ b/roles/cloudera_manager/daemons/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Install Cloudera Manager daemons package
   ansible.builtin.package:

--- a/roles/cloudera_manager/database/tasks/main.yml
+++ b/roles/cloudera_manager/database/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Configure Cloudera Manager database (external)
   include_tasks: external.yml
   when: not cloudera_manager_database_embedded

--- a/roles/cloudera_manager/database/tasks/main.yml
+++ b/roles/cloudera_manager/database/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Configure Cloudera Manager database (external)
   include_tasks: external.yml

--- a/roles/cloudera_manager/external_account/tasks/main.yml
+++ b/roles/cloudera_manager/external_account/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Wait for Cloudera Manager Port to be up
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"

--- a/roles/cloudera_manager/external_account/tasks/main.yml
+++ b/roles/cloudera_manager/external_account/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Wait for Cloudera Manager Port to be up
   delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
   ansible.builtin.wait_for:

--- a/roles/cloudera_manager/external_auth/tasks/main.yml
+++ b/roles/cloudera_manager/external_auth/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Conditionally load in variables for initializing IPA
   ansible.builtin.include_vars:

--- a/roles/cloudera_manager/external_auth/tasks/main.yml
+++ b/roles/cloudera_manager/external_auth/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Conditionally load in variables for initializing IPA
   ansible.builtin.include_vars:
     file: freeipa.yml

--- a/roles/cloudera_manager/hosts_config/tasks/main.yml
+++ b/roles/cloudera_manager/hosts_config/tasks/main.yml
@@ -17,6 +17,18 @@
 # Edit with extreme caution
 # This plays are imported from a separate playbook so that Ansible tags are intuitively propagated from main.yml
 
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Apply "all hosts" configs
   include_role:
     name: cloudera.cluster.cloudera_manager.config

--- a/roles/cloudera_manager/hosts_config/tasks/main.yml
+++ b/roles/cloudera_manager/hosts_config/tasks/main.yml
@@ -17,17 +17,11 @@
 # Edit with extreme caution
 # This plays are imported from a separate playbook so that Ansible tags are intuitively propagated from main.yml
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Apply "all hosts" configs
   include_role:

--- a/roles/cloudera_manager/kerberos/tasks/main.yml
+++ b/roles/cloudera_manager/kerberos/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Set Cloudera Manager Kerberos configs
   include_role:
     name: cloudera.cluster.cloudera_manager.config

--- a/roles/cloudera_manager/kerberos/tasks/main.yml
+++ b/roles/cloudera_manager/kerberos/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Set Cloudera Manager Kerberos configs
   include_role:

--- a/roles/cloudera_manager/license/tasks/main.yml
+++ b/roles/cloudera_manager/license/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Upload enterprise license
   include_tasks: enterprise.yml

--- a/roles/cloudera_manager/license/tasks/main.yml
+++ b/roles/cloudera_manager/license/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Upload enterprise license
   include_tasks: enterprise.yml
   when: cloudera_manager_license_type == 'enterprise'

--- a/roles/cloudera_manager/preload_parcels/tasks/main.yml
+++ b/roles/cloudera_manager/preload_parcels/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Ensure Parcel Repo directory is present
   ansible.builtin.file:
     path: /opt/cloudera/parcel-repo

--- a/roles/cloudera_manager/preload_parcels/tasks/main.yml
+++ b/roles/cloudera_manager/preload_parcels/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Ensure Parcel Repo directory is present
   ansible.builtin.file:

--- a/roles/cloudera_manager/repo/tasks/main.yml
+++ b/roles/cloudera_manager/repo/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include variables
   include_vars:
     file: "{{ ansible_os_family }}.yml"

--- a/roles/cloudera_manager/repo/tasks/main.yml
+++ b/roles/cloudera_manager/repo/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include variables
   include_vars:

--- a/roles/cloudera_manager/server/tasks/main.yml
+++ b/roles/cloudera_manager/server/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Gather the package facts
   ansible.builtin.package_facts:

--- a/roles/cloudera_manager/server/tasks/main.yml
+++ b/roles/cloudera_manager/server/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/roles/cloudera_manager/server_tls/tasks/main.yml
+++ b/roles/cloudera_manager/server_tls/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Set Cloudera Manager TLS configs
   include_role:

--- a/roles/cloudera_manager/server_tls/tasks/main.yml
+++ b/roles/cloudera_manager/server_tls/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Set Cloudera Manager TLS configs
   include_role:
     name: cloudera.cluster.cloudera_manager.config

--- a/roles/cloudera_manager/services_info/tasks/main.yml
+++ b/roles/cloudera_manager/services_info/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Get All services from CM
   cloudera.cluster.cm_api:
     endpoint: "/clusters/{{ cluster_name | urlencode() }}/services"

--- a/roles/cloudera_manager/services_info/tasks/main.yml
+++ b/roles/cloudera_manager/services_info/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Get All services from CM
   cloudera.cluster.cm_api:

--- a/roles/cloudera_manager/session_timeout/tasks/main.yml
+++ b/roles/cloudera_manager/session_timeout/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Set session timeout to 30 days
   cloudera.cluster.cm_api:

--- a/roles/cloudera_manager/session_timeout/tasks/main.yml
+++ b/roles/cloudera_manager/session_timeout/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Set session timeout to 30 days
   cloudera.cluster.cm_api:
     endpoint: /cm/config

--- a/roles/cloudera_manager/wait_for_heartbeat/tasks/main.yml
+++ b/roles/cloudera_manager/wait_for_heartbeat/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Read the Cloudera Manager agent UUID
   slurp:
     path: "{{ cloudera_manager_agent_lib_directory }}/uuid"

--- a/roles/cloudera_manager/wait_for_heartbeat/tasks/main.yml
+++ b/roles/cloudera_manager/wait_for_heartbeat/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Read the Cloudera Manager agent UUID
   slurp:

--- a/roles/config/cluster/base/tasks/main.yml
+++ b/roles/config/cluster/base/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 # This variable is used by other roles
 # please take care when changing it

--- a/roles/config/cluster/base/tasks/main.yml
+++ b/roles/config/cluster/base/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 # This variable is used by other roles
 # please take care when changing it
 - set_fact:

--- a/roles/config/cluster/ecs/tasks/main.yml
+++ b/roles/config/cluster/ecs/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 # This variable is used by other roles
 # please take care when changing it

--- a/roles/config/cluster/ecs/tasks/main.yml
+++ b/roles/config/cluster/ecs/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 # This variable is used by other roles
 # please take care when changing it
 - set_fact:

--- a/roles/config/cluster/kts/tasks/main.yml
+++ b/roles/config/cluster/kts/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Retrieve repository metadata
   include_role:

--- a/roles/config/cluster/kts/tasks/main.yml
+++ b/roles/config/cluster/kts/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Retrieve repository metadata
   include_role:
     name: cloudera.cluster.deployment.repometa

--- a/roles/config/services/hue_ticket_lifetime/tasks/main.yml
+++ b/roles/config/services/hue_ticket_lifetime/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Fix Hue ticket lifetime for Free IPA
   shell: |

--- a/roles/config/services/hue_ticket_lifetime/tasks/main.yml
+++ b/roles/config/services/hue_ticket_lifetime/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Fix Hue ticket lifetime for Free IPA
   shell: |
     kadmin -p "{{ ipa_admin_user }}" -w "{{ ipaadmin_password }}" -q "modprinc -maxrenewlife 90day +allow_renewable hue/{{ __hue_ticket_item }}@{{ krb5_realm }}" ;

--- a/roles/config/services/kms/tasks/main.yml
+++ b/roles/config/services/kms/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Reset custom configuration dictionary
   set_fact:

--- a/roles/config/services/kms/tasks/main.yml
+++ b/roles/config/services/kms/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Reset custom configuration dictionary
   set_fact:
     merged_configs: {}

--- a/roles/config/services/kms_tls/tasks/main.yml
+++ b/roles/config/services/kms_tls/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Push TLS settings for Ranger KMS
   cloudera.cluster.cm_api:
     endpoint: "/clusters/{{ cluster_name | urlencode() }}/services/{{ kms_service_name | lower }}/roleConfigGroups/{{ kms_service_name | lower }}-RANGER_KMS_SERVER_KTS-BASE/config"

--- a/roles/config/services/kms_tls/tasks/main.yml
+++ b/roles/config/services/kms_tls/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Push TLS settings for Ranger KMS
   cloudera.cluster.cm_api:

--- a/roles/config/services/mgmt/tasks/main.yml
+++ b/roles/config/services/mgmt/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 # This variable is used by other roles
 # please take care when changing it

--- a/roles/config/services/mgmt/tasks/main.yml
+++ b/roles/config/services/mgmt/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 # This variable is used by other roles
 # please take care when changing it
 - set_fact:

--- a/roles/config/services/oozie_ui/tasks/main.yml
+++ b/roles/config/services/oozie_ui/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 # From:  https://docs.cloudera.com/cdp-private-cloud-base/7.1.7/configuring-oozie/topics/oozie-enabling-the-oozie-web-console-on-managed-clusters.html
 

--- a/roles/config/services/oozie_ui/tasks/main.yml
+++ b/roles/config/services/oozie_ui/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 # From:  https://docs.cloudera.com/cdp-private-cloud-base/7.1.7/configuring-oozie/topics/oozie-enabling-the-oozie-web-console-on-managed-clusters.html
 
 - name: Download ext-2.2 file

--- a/roles/config/services/ranger_pvc_default_policies/tasks/main.yml
+++ b/roles/config/services/ranger_pvc_default_policies/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Post Ranger policies declared in policies directory
   register: __ranger_pol_response
   uri:

--- a/roles/config/services/ranger_pvc_default_policies/tasks/main.yml
+++ b/roles/config/services/ranger_pvc_default_policies/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Post Ranger policies declared in policies directory
   register: __ranger_pol_response

--- a/roles/config/services/solr_knox/tasks/main.yml
+++ b/roles/config/services/solr_knox/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 # Add Solr host to Knox
 - name: add solr host in config

--- a/roles/config/services/solr_knox/tasks/main.yml
+++ b/roles/config/services/solr_knox/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 # Add Solr host to Knox
 - name: add solr host in config
   include_tasks: add_solr_knox_host.yml

--- a/roles/config/services/solr_ranger_plugin/tasks/main.yml
+++ b/roles/config/services/solr_ranger_plugin/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Create in Ranger the SolR service
   register: __ranger_solr_plugin

--- a/roles/config/services/solr_ranger_plugin/tasks/main.yml
+++ b/roles/config/services/solr_ranger_plugin/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Create in Ranger the SolR service
   register: __ranger_solr_plugin
   uri:

--- a/roles/deployment/cluster/tasks/main.yml
+++ b/roles/deployment/cluster/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include config cluster defaults for deployment
   ansible.builtin.include_role:

--- a/roles/deployment/cluster/tasks/main.yml
+++ b/roles/deployment/cluster/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include config cluster defaults for deployment
   ansible.builtin.include_role:
     name: cloudera.cluster.config.cluster.common

--- a/roles/deployment/credential/tasks/main.yml
+++ b/roles/deployment/credential/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Derive License Content
   when: cloudera_manager_license_file
   block:

--- a/roles/deployment/credential/tasks/main.yml
+++ b/roles/deployment/credential/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Derive License Content
   when: cloudera_manager_license_file

--- a/roles/deployment/databases/tasks/main.yml
+++ b/roles/deployment/databases/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Create databases and users
   include_tasks:

--- a/roles/deployment/databases/tasks/main.yml
+++ b/roles/deployment/databases/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Create databases and users
   include_tasks:
     file: "{{ database_type }}.yml"

--- a/roles/deployment/definition/tasks/main.yml
+++ b/roles/deployment/definition/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Generate host_template cluster map
   ansible.builtin.set_fact:
     _host_template_cluster_map: "{{ lookup('template', './template_cluster_map.j2') | from_yaml }}"

--- a/roles/deployment/definition/tasks/main.yml
+++ b/roles/deployment/definition/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "{{ ansible_role_name }} is no longer supported."
+    version: 6.0.0
 
 - name: Generate host_template cluster map
   ansible.builtin.set_fact:

--- a/roles/deployment/groupby/tasks/main.yml
+++ b/roles/deployment/groupby/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Group by host template
   group_by:
     key: "{{ 'host_template_' ~ host_template if host_template is defined else 'no_template' }}"

--- a/roles/deployment/groupby/tasks/main.yml
+++ b/roles/deployment/groupby/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Group by host template
   group_by:

--- a/roles/deployment/repometa/tasks/main.yml
+++ b/roles/deployment/repometa/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Determine OS-specific values
   include_tasks:
     file: "prepare-{{ ansible_os_family }}.yml"

--- a/roles/deployment/repometa/tasks/main.yml
+++ b/roles/deployment/repometa/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Determine OS-specific values
   include_tasks:

--- a/roles/deployment/services/kms/tasks/main.yml
+++ b/roles/deployment/services/kms/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Get Key Trustee organisation auth secret
   shell: >

--- a/roles/deployment/services/kms/tasks/main.yml
+++ b/roles/deployment/services/kms/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Get Key Trustee organisation auth secret
   shell: >
     keytrustee-orgtool --confdir {{ keytrustee_server_conf_dir }} list

--- a/roles/deployment/services/kms_ha/tasks/main.yml
+++ b/roles/deployment/services/kms_ha/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Create temp directory for keys
   file:
     path: "{{ local_temp_dir }}/kms"

--- a/roles/deployment/services/kms_ha/tasks/main.yml
+++ b/roles/deployment/services/kms_ha/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Create temp directory for keys
   file:

--- a/roles/deployment/services/kts_high_availability/tasks/main.yml
+++ b/roles/deployment/services/kts_high_availability/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Query for KTS Cluster
   set_fact:

--- a/roles/deployment/services/kts_high_availability/tasks/main.yml
+++ b/roles/deployment/services/kts_high_availability/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Query for KTS Cluster
   set_fact:
     kts_cluster: "{{ definition.clusters | json_query('[?type==`kts`]') | first }}"

--- a/roles/deployment/services/mgmt/tasks/main.yml
+++ b/roles/deployment/services/mgmt/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Generate mgmt configs
   include_role:

--- a/roles/deployment/services/mgmt/tasks/main.yml
+++ b/roles/deployment/services/mgmt/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Generate mgmt configs
   include_role:
     name: cloudera.cluster.config.services.mgmt

--- a/roles/deployment/services/wxm/tasks/main.yml
+++ b/roles/deployment/services/wxm/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - assert:
     that:
       - altus_private_key | length > 0

--- a/roles/deployment/services/wxm/tasks/main.yml
+++ b/roles/deployment/services/wxm/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - assert:
     that:

--- a/roles/infrastructure/ca_server/tasks/main.yml
+++ b/roles/infrastructure/ca_server/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include OS-specific variables
   include_vars:
     file: "{{ ansible_os_family }}.yml"

--- a/roles/infrastructure/ca_server/tasks/main.yml
+++ b/roles/infrastructure/ca_server/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include OS-specific variables
   include_vars:

--- a/roles/infrastructure/custom_repo/tasks/main.yml
+++ b/roles/infrastructure/custom_repo/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include variables
   include_vars:
     file: "{{ ansible_os_family }}.yml"

--- a/roles/infrastructure/custom_repo/tasks/main.yml
+++ b/roles/infrastructure/custom_repo/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include variables
   include_vars:

--- a/roles/infrastructure/haproxy/tasks/main.yml
+++ b/roles/infrastructure/haproxy/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Install HAProxy
   ansible.builtin.package:
     lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(60, omit) }}"

--- a/roles/infrastructure/haproxy/tasks/main.yml
+++ b/roles/infrastructure/haproxy/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Install HAProxy
   ansible.builtin.package:

--- a/roles/infrastructure/krb5_client/tasks/main.yml
+++ b/roles/infrastructure/krb5_client/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Install MIT KRB5 Client setup
   when: krb5_kdc_type != 'Red Hat IPA'

--- a/roles/infrastructure/krb5_client/tasks/main.yml
+++ b/roles/infrastructure/krb5_client/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Install MIT KRB5 Client setup
   when: krb5_kdc_type != 'Red Hat IPA'
   ansible.builtin.include_tasks: mit.yml

--- a/roles/infrastructure/krb5_conf/tasks/main.yml
+++ b/roles/infrastructure/krb5_conf/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Setup MIT KRB5 Configuration
   when: krb5_kdc_type != 'Red Hat IPA'
   ansible.builtin.include_tasks: mit.yml

--- a/roles/infrastructure/krb5_conf/tasks/main.yml
+++ b/roles/infrastructure/krb5_conf/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Setup MIT KRB5 Configuration
   when: krb5_kdc_type != 'Red Hat IPA'

--- a/roles/infrastructure/krb5_server/tasks/main.yml
+++ b/roles/infrastructure/krb5_server/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Install MIT KDC Server
   when: krb5_kdc_type == 'MIT KDC'

--- a/roles/infrastructure/krb5_server/tasks/main.yml
+++ b/roles/infrastructure/krb5_server/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Install MIT KDC Server
   when: krb5_kdc_type == 'MIT KDC'
   ansible.builtin.include_tasks: mit.yml

--- a/roles/infrastructure/rdbms/tasks/main.yml
+++ b/roles/infrastructure/rdbms/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include database type specific variables
   include_vars:
     file: "{{ database_type }}.yml"

--- a/roles/infrastructure/rdbms/tasks/main.yml
+++ b/roles/infrastructure/rdbms/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include database type specific variables
   include_vars:

--- a/roles/operations/delete_cluster/tasks/main.yml
+++ b/roles/operations/delete_cluster/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Check the cluster exists
   cloudera.cluster.cm_api:

--- a/roles/operations/delete_cluster/tasks/main.yml
+++ b/roles/operations/delete_cluster/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Check the cluster exists
   cloudera.cluster.cm_api:
     endpoint: /clusters/{{ cluster.name | urlencode() }}

--- a/roles/operations/delete_cms/tasks/main.yml
+++ b/roles/operations/delete_cms/tasks/main.yml
@@ -15,10 +15,10 @@
 ---
 
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Check cms exists
   cloudera.cluster.cm_api:

--- a/roles/operations/delete_cms/tasks/main.yml
+++ b/roles/operations/delete_cms/tasks/main.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Check cms exists
   cloudera.cluster.cm_api:
     endpoint: /cm/service

--- a/roles/operations/refresh_ranger_kms_repo/tasks/main.yml
+++ b/roles/operations/refresh_ranger_kms_repo/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Refresh the KMS repository
   include_tasks: setup_cluster.yml

--- a/roles/operations/refresh_ranger_kms_repo/tasks/main.yml
+++ b/roles/operations/refresh_ranger_kms_repo/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Refresh the KMS repository
   include_tasks: setup_cluster.yml
   loop: "{{ definition.clusters }}"

--- a/roles/operations/restart_cluster/tasks/main.yml
+++ b/roles/operations/restart_cluster/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Restart cluster
   cm_api:

--- a/roles/operations/restart_cluster/tasks/main.yml
+++ b/roles/operations/restart_cluster/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Restart cluster
   cm_api:
     endpoint: /clusters/{{ cluster_to_restart }}/commands/restart

--- a/roles/operations/restart_cluster_services/tasks/main.yml
+++ b/roles/operations/restart_cluster_services/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Get All services from CM
   cloudera.cluster.cm_api:

--- a/roles/operations/restart_cluster_services/tasks/main.yml
+++ b/roles/operations/restart_cluster_services/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Get All services from CM
   cloudera.cluster.cm_api:
     endpoint: "/clusters/{{ cluster_name | urlencode() }}/services"

--- a/roles/operations/restart_mgmt_services/tasks/main.yml
+++ b/roles/operations/restart_mgmt_services/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Restart Cloudera Manager Management Services
   cloudera.cluster.cm_api:
     endpoint: "/cm/service/roleCommands/restart"

--- a/roles/operations/restart_mgmt_services/tasks/main.yml
+++ b/roles/operations/restart_mgmt_services/tasks/main.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Restart Cloudera Manager Management Services
   cloudera.cluster.cm_api:

--- a/roles/operations/restart_stale/tasks/main.yml
+++ b/roles/operations/restart_stale/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Get clusters
   cloudera.cluster.cm_api:

--- a/roles/operations/restart_stale/tasks/main.yml
+++ b/roles/operations/restart_stale/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Get clusters
   cloudera.cluster.cm_api:
     endpoint: /clusters

--- a/roles/operations/stop_cluster/tasks/main.yml
+++ b/roles/operations/stop_cluster/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Check the cluster exists
   cloudera.cluster.cm_api:

--- a/roles/operations/stop_cluster/tasks/main.yml
+++ b/roles/operations/stop_cluster/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Check the cluster exists
   cloudera.cluster.cm_api:
     endpoint: /clusters/{{ cluster.name | urlencode() }}

--- a/roles/prereqs/jdk/tasks/main.yml
+++ b/roles/prereqs/jdk/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include variables
   include_vars:
     file: "{{ ansible_os_family }}.yml"

--- a/roles/prereqs/jdk/tasks/main.yml
+++ b/roles/prereqs/jdk/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include variables
   include_vars:

--- a/roles/prereqs/kerberos/tasks/main.yml
+++ b/roles/prereqs/kerberos/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include variables
   include_vars:
     file: "{{ ansible_os_family }}.yml"

--- a/roles/prereqs/kerberos/tasks/main.yml
+++ b/roles/prereqs/kerberos/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include variables
   include_vars:

--- a/roles/prereqs/license/tasks/main.yml
+++ b/roles/prereqs/license/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Copy Cloudera License File to temp path for Cloudera Manager
   copy:
     src: "{{ cloudera_manager_license_file }}"

--- a/roles/prereqs/license/tasks/main.yml
+++ b/roles/prereqs/license/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Copy Cloudera License File to temp path for Cloudera Manager
   copy:

--- a/roles/prereqs/mysql_connector/tasks/main.yml
+++ b/roles/prereqs/mysql_connector/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Download MySQL Connector/J
   get_url:
     url: "{{ mysql_connector_url }}"

--- a/roles/prereqs/mysql_connector/tasks/main.yml
+++ b/roles/prereqs/mysql_connector/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Download MySQL Connector/J
   get_url:

--- a/roles/prereqs/oracle_connector/tasks/main.yml
+++ b/roles/prereqs/oracle_connector/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Setup the Oracle JDBC Driver
   block:
     - name: Download Oracle Connector

--- a/roles/prereqs/oracle_connector/tasks/main.yml
+++ b/roles/prereqs/oracle_connector/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Setup the Oracle JDBC Driver
   block:

--- a/roles/prereqs/os/tasks/main.yml
+++ b/roles/prereqs/os/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include variables
   include_vars:
     file: "{{ ansible_os_family }}.yml"

--- a/roles/prereqs/os/tasks/main.yml
+++ b/roles/prereqs/os/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include variables
   include_vars:

--- a/roles/prereqs/postgresql_connector/tasks/main.yml
+++ b/roles/prereqs/postgresql_connector/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Download PostgreSQL Connector
   get_url:

--- a/roles/prereqs/postgresql_connector/tasks/main.yml
+++ b/roles/prereqs/postgresql_connector/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Download PostgreSQL Connector
   get_url:
     url: "{{ postgresql_connector_url }}"

--- a/roles/prereqs/pvc_ecs/tasks/main.yml
+++ b/roles/prereqs/pvc_ecs/tasks/main.yml
@@ -14,17 +14,11 @@
 # limitations under the License.
 
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Fail Fast if ECS OS is not RH family
   ansible.builtin.fail:

--- a/roles/prereqs/pvc_ecs/tasks/main.yml
+++ b/roles/prereqs/pvc_ecs/tasks/main.yml
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Fail Fast if ECS OS is not RH family
   ansible.builtin.fail:
     msg: ECS is not supported on this OS, should be Centos or RHEL

--- a/roles/prereqs/user_accounts/tasks/main.yml
+++ b/roles/prereqs/user_accounts/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - block:
     - name: Create hadoop group
       group:

--- a/roles/prereqs/user_accounts/tasks/main.yml
+++ b/roles/prereqs/user_accounts/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - block:
     - name: Create hadoop group

--- a/roles/prereqs/user_accounts_ecs/tasks/main.yml
+++ b/roles/prereqs/user_accounts_ecs/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - block:
     - name: Create hadoop group
       group:

--- a/roles/prereqs/user_accounts_ecs/tasks/main.yml
+++ b/roles/prereqs/user_accounts_ecs/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - block:
     - name: Create hadoop group

--- a/roles/security/tls_clean/tasks/main.yml
+++ b/roles/security/tls_clean/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Delete security artifacts
   file:
     name: "{{ base_dir_security }}"

--- a/roles/security/tls_clean/tasks/main.yml
+++ b/roles/security/tls_clean/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Delete security artifacts
   file:

--- a/roles/security/tls_generate_csr/tasks/main.yml
+++ b/roles/security/tls_generate_csr/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Prepare directories for TLS
   file:
     state: directory

--- a/roles/security/tls_generate_csr/tasks/main.yml
+++ b/roles/security/tls_generate_csr/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Prepare directories for TLS
   file:

--- a/roles/security/tls_install_certs/tasks/main.yml
+++ b/roles/security/tls_install_certs/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Set fact for signed TLS certificates directory
   ansible.builtin.set_fact:

--- a/roles/security/tls_install_certs/tasks/main.yml
+++ b/roles/security/tls_install_certs/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Set fact for signed TLS certificates directory
   ansible.builtin.set_fact:
     tls_signed_certs_dir: "{{ local_certs_dir }}"

--- a/roles/security/tls_nifi/tasks/main.yml
+++ b/roles/security/tls_nifi/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Ensure the NiFi home directory exists
   file:
     path: "{{ nifi_dir_path }}"

--- a/roles/security/tls_nifi/tasks/main.yml
+++ b/roles/security/tls_nifi/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Ensure the NiFi home directory exists
   file:

--- a/roles/security/tls_signing/tasks/main.yml
+++ b/roles/security/tls_signing/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Sign CSRs with locally installed CA
   include_tasks: csr_signing_local.yml

--- a/roles/security/tls_signing/tasks/main.yml
+++ b/roles/security/tls_signing/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Sign CSRs with locally installed CA
   include_tasks: csr_signing_local.yml
   when: "'ca_server' in groups"

--- a/roles/teardown/tasks/main.yml
+++ b/roles/teardown/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Include config cluster defaults for deployment
   ansible.builtin.include_role:

--- a/roles/teardown/tasks/main.yml
+++ b/roles/teardown/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Include config cluster defaults for deployment
   ansible.builtin.include_role:
     name: cloudera.cluster.config.cluster.common

--- a/roles/verify/definition/tasks/main.yml
+++ b/roles/verify/definition/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 # Inventory specific
 - block:

--- a/roles/verify/definition/tasks/main.yml
+++ b/roles/verify/definition/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 # Inventory specific
 - block:
     - set_fact:

--- a/roles/verify/inventory/tasks/main.yml
+++ b/roles/verify/inventory/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Fail if inventory groups are empty
   fail:
     msg: Ensure that all inventory groups are non-empty

--- a/roles/verify/inventory/tasks/main.yml
+++ b/roles/verify/inventory/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Fail if inventory groups are empty
   fail:

--- a/roles/verify/parcels_and_roles/tasks/main.yml
+++ b/roles/verify/parcels_and_roles/tasks/main.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Load defaults
-  when: deprecation_msg is defined
-  run_once: true
-  ansible.builtin.include_role:
-    name: cloudera.cluster.cloudera_manager.common
-
 - name: Deprecation warning
-  when: deprecation_msg is defined
   run_once: true
-  cloudera.cluster.warn:
-    msg: "{{ deprecation_msg }}"
+  cloudera.cluster.deprecation:
+    msg: "Role, {{ ansible_role_name }}, is no longer supported."
+    version: 6.0.0
 
 - name: Ensure cluster services and roles are valid
   include_tasks: check_cluster.yml

--- a/roles/verify/parcels_and_roles/tasks/main.yml
+++ b/roles/verify/parcels_and_roles/tasks/main.yml
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 ---
+
+- name: Load defaults
+  when: deprecation_msg is defined
+  run_once: true
+  ansible.builtin.include_role:
+    name: cloudera.cluster.cloudera_manager.common
+
+- name: Deprecation warning
+  when: deprecation_msg is defined
+  run_once: true
+  cloudera.cluster.warn:
+    msg: "{{ deprecation_msg }}"
+
 - name: Ensure cluster services and roles are valid
   include_tasks: check_cluster.yml
   loop: "{{ definition.clusters }}"


### PR DESCRIPTION
Adds a (hopefully temporary!) `cloudera.cluster.warn` module to display the deprecation notice and inserts a task in each `main.yml` of the legacy roles to show the warning.