### PR TITLE
Fix external_user_mapping module

### DIFF
--- a/plugins/modules/external_user_mappings.py
+++ b/plugins/modules/external_user_mappings.py
@@ -256,7 +256,6 @@ class ClouderaExternalUserMappingsInfo(ClouderaManagerModule):
                 auth_roles = [ApiAuthRoleRef(name=role) for role in self.auth_roles]
                 external_user_mappings_body = ApiExternalUserMapping(
                     name=self.name,
-                    uuid=mapping.uuid,
                     type=self.type,
                     auth_roles=auth_roles,
                 )


### PR DESCRIPTION
When creating new external_user_mappings, I get this error: `UnboundLocalError: local variable 'mapping' referenced before assignment`. I think I've traced this back to the simple change in this PR. I've tests the unit tests for external user mappings with this change and all run successfully.